### PR TITLE
feat: Sort Excel detail sheets alphabetically by table name

### DIFF
--- a/src/PowerApps.CLI/Services/ComparisonReporter.cs
+++ b/src/PowerApps.CLI/Services/ComparisonReporter.cs
@@ -23,8 +23,13 @@ public class ComparisonReporter : IComparisonReporter
         // Add summary sheet
         AddSummarySheet(workbook, result);
 
-        // Add detail sheets only for tables with differences
-        foreach (var tableResult in result.TableResults.Where(t => t.HasDifferences))
+        // Add detail sheets only for tables with differences, sorted alphabetically by TableName
+        var sortedTableResults = result.TableResults
+            .Where(t => t.HasDifferences)
+            .OrderBy(t => t.TableName)
+            .ToList();
+
+        foreach (var tableResult in sortedTableResults)
         {
             AddTableDetailSheet(workbook, tableResult);
         }


### PR DESCRIPTION
## Summary
Fixes the ordering of Excel worksheets in refdata-compare reports.

## Changes
- Detail sheets are now sorted alphabetically by TableName
- Summary sheet table list remains alphabetically sorted (already was)
- Improves navigation when working with reports containing many tables (e.g., 36+ tables)

## Testing
- ✅ All existing ComparisonReporter tests pass
- Verified that sorting does not affect worksheet content, only order

Fixes #14