### PR TITLE
Centralise Dataverse SDK logic into IDataverseClient

### DIFF
--- a/src/PowerApps.CLI/Commands/ProcessManageCommand.cs
+++ b/src/PowerApps.CLI/Commands/ProcessManageCommand.cs
@@ -74,7 +74,6 @@ public static class ProcessManageCommand
             // Create service instances
             var logger = new ConsoleLogger { IsVerboseEnabled = verbose };
             var fileWriter = new FileWriter();
-            var processManager = new ProcessManager(logger);
             var processReporter = new ProcessReporter(fileWriter);
 
             try
@@ -104,9 +103,11 @@ public static class ProcessManageCommand
                 var envUrl = dataverseClient.GetEnvironmentUrl();
                 logger.LogSuccess($"Connected to: {envUrl}");
 
+                var processManager = new ProcessManager(logger, dataverseClient);
+
                 // Retrieve processes
                 logger.LogInfo("Retrieving processes...");
-                var processes = processManager.RetrieveProcesses(dataverseClient, config.Solutions);
+                var processes = processManager.RetrieveProcesses(config.Solutions);
                 logger.LogInfo($"Found {processes.Count} process(es)");
 
                 // Determine expected states
@@ -125,7 +126,7 @@ public static class ProcessManageCommand
 
                 // Manage process states
                 logger.LogInfo(dryRun ? "Simulating state changes..." : "Applying state changes...");
-                var summary = processManager.ManageProcessStates(dataverseClient, processes, dryRun, config.MaxRetries);
+                var summary = processManager.ManageProcessStates(processes, dryRun, config.MaxRetries);
                 summary.EnvironmentUrl = envUrl;
 
                 // Generate report

--- a/src/PowerApps.CLI/Commands/SchemaCommand.cs
+++ b/src/PowerApps.CLI/Commands/SchemaCommand.cs
@@ -106,8 +106,6 @@ public static class SchemaCommand
                 output,
                 format,
                 connectionString,
-                clientId,
-                clientSecret,
                 attributePrefix,
                 excludeAttributes);
         });
@@ -123,8 +121,6 @@ public static class SchemaCommand
         string output,
         string format,
         string? connectionString,
-        string? clientId,
-        string? clientSecret,
         string? attributePrefix,
         string? excludeAttributes)
     {
@@ -140,7 +136,7 @@ public static class SchemaCommand
 
             logger.LogInfo("PowerApps Schema Export");
             logger.LogInfo("======================\n");
-            
+
             if (!string.IsNullOrWhiteSpace(url))
             {
                 logger.LogVerbose($"Environment URL: {url}");
@@ -148,28 +144,24 @@ public static class SchemaCommand
             logger.LogVerbose($"Solution: {solution ?? "(all metadata)"}");
             logger.LogVerbose($"Output: {output}");
             logger.LogVerbose($"Format: {format}");
-            
+
             if (!string.IsNullOrWhiteSpace(attributePrefix))
             {
                 logger.LogVerbose($"Attribute Prefix Filter: {attributePrefix}");
             }
-            
+
             if (!string.IsNullOrWhiteSpace(excludeAttributes))
             {
                 logger.LogVerbose($"Excluded Attributes: {excludeAttributes}");
             }
-            
+
             logger.LogInfo("Connecting to PowerApps environment...");
 
             // Export schema (service will handle the export logic)
             await schemaService.ExportSchemaAsync(
-                url,
                 output,
                 format,
                 solution,
-                connectionString,
-                clientId,
-                clientSecret,
                 attributePrefix,
                 excludeAttributes);
 

--- a/src/PowerApps.CLI/Infrastructure/IDataverseClient.cs
+++ b/src/PowerApps.CLI/Infrastructure/IDataverseClient.cs
@@ -1,4 +1,3 @@
-using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
@@ -65,4 +64,30 @@ public interface IDataverseClient
     /// <param name="filters">The metadata filters to apply.</param>
     /// <returns>The entity metadata, or null if not found.</returns>
     Task<EntityMetadata?> GetEntityMetadataAsync(string entityLogicalName, EntityFilters filters);
+
+    /// <summary>
+    /// Retrieves workflow/process records, optionally filtered by solution names.
+    /// </summary>
+    /// <param name="solutions">Solution unique names to filter by. If empty, retrieves all processes.</param>
+    /// <returns>Collection of workflow entities.</returns>
+    EntityCollection RetrieveProcesses(List<string> solutions);
+
+    /// <summary>
+    /// Activates a workflow/process.
+    /// </summary>
+    /// <param name="processId">The ID of the process to activate.</param>
+    void ActivateProcess(Guid processId);
+
+    /// <summary>
+    /// Deactivates a workflow/process.
+    /// </summary>
+    /// <param name="processId">The ID of the process to deactivate.</param>
+    void DeactivateProcess(Guid processId);
+
+    /// <summary>
+    /// Retrieves records using a FetchXML query.
+    /// </summary>
+    /// <param name="fetchXml">The FetchXML query string.</param>
+    /// <returns>Collection of entities matching the query.</returns>
+    EntityCollection RetrieveRecordsByFetchXml(string fetchXml);
 }

--- a/src/PowerApps.CLI/Services/IProcessManager.cs
+++ b/src/PowerApps.CLI/Services/IProcessManager.cs
@@ -1,4 +1,3 @@
-using PowerApps.CLI.Infrastructure;
 using PowerApps.CLI.Models;
 
 namespace PowerApps.CLI.Services;
@@ -11,7 +10,7 @@ public interface IProcessManager
     /// <summary>
     /// Retrieves all processes from specified solutions.
     /// </summary>
-    List<ProcessInfo> RetrieveProcesses(IDataverseClient client, List<string> solutions);
+    List<ProcessInfo> RetrieveProcesses(List<string> solutions);
 
     /// <summary>
     /// Determines expected state for processes based on inactive patterns.
@@ -22,7 +21,6 @@ public interface IProcessManager
     /// Manages process states to match expected states.
     /// </summary>
     ProcessManageSummary ManageProcessStates(
-        IDataverseClient client,
         List<ProcessInfo> processes,
         bool isDryRun,
         int maxRetries);

--- a/src/PowerApps.CLI/Services/ISchemaService.cs
+++ b/src/PowerApps.CLI/Services/ISchemaService.cs
@@ -8,23 +8,15 @@ public interface ISchemaService
     /// <summary>
     /// Exports schema from a Dataverse environment to a file.
     /// </summary>
-    /// <param name="url">The Dataverse environment URL (optional if connectionString is provided).</param>
     /// <param name="outputPath">The output file path.</param>
     /// <param name="format">The output format (json, xlsx).</param>
     /// <param name="solutionName">Optional solution name to filter by.</param>
-    /// <param name="connectionString">Optional connection string.</param>
-    /// <param name="clientId">Optional Azure AD Application (Client) ID.</param>
-    /// <param name="clientSecret">Optional Azure AD Application Client Secret.</param>
     /// <param name="attributePrefix">Optional attribute prefix filter.</param>
     /// <param name="excludeAttributes">Optional comma-separated list of attributes to exclude.</param>
     Task ExportSchemaAsync(
-        string? url,
         string outputPath,
         string format,
         string? solutionName = null,
-        string? connectionString = null,
-        string? clientId = null,
-        string? clientSecret = null,
         string? attributePrefix = null,
         string? excludeAttributes = null);
 }

--- a/src/PowerApps.CLI/Services/SchemaService.cs
+++ b/src/PowerApps.CLI/Services/SchemaService.cs
@@ -25,13 +25,9 @@ public class SchemaService : ISchemaService
     }
 
     public async Task ExportSchemaAsync(
-        string? url,
         string outputPath,
         string format,
         string? solutionName = null,
-        string? connectionString = null,
-        string? clientId = null,
-        string? clientSecret = null,
         string? attributePrefix = null,
         string? excludeAttributes = null)
     {
@@ -54,21 +50,13 @@ public class SchemaService : ISchemaService
         _logger.LogInfo("Extracting schema...");
 
         var schema = await _schemaExtractor.ExtractSchemaAsync(solutionName);
-        
+
         _logger.LogSuccess($"✓ Extracted {schema.Entities?.Count ?? 0} entities");
 
         // Export schema to file
         _logger.LogInfo($"Writing {format.ToUpperInvariant()} file...");
         await _schemaExporter.ExportAsync(schema, outputPath, format);
-        
-        _logger.LogSuccess($"✓ Schema exported to {outputPath}");
-    }
 
-    private static string? ExtractUrlFromConnectionString(string connectionString)
-    {
-        // Extract URL from connection string for logging
-        var urlPattern = "Url=([^;]+)";
-        var match = System.Text.RegularExpressions.Regex.Match(connectionString, urlPattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-        return match.Success ? match.Groups[1].Value : null;
+        _logger.LogSuccess($"✓ Schema exported to {outputPath}");
     }
 }

--- a/tests/PowerApps.CLI.Tests/Services/SchemaServiceTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/SchemaServiceTests.cs
@@ -92,7 +92,7 @@ public class SchemaServiceTests
     {
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-            _service.ExportSchemaAsync("https://test.crm.dynamics.com", null!, "json"));
+            _service.ExportSchemaAsync(null!, "json"));
 
         Assert.Contains("Output path cannot be null or whitespace", exception.Message);
         Assert.Equal("outputPath", exception.ParamName);
@@ -103,7 +103,7 @@ public class SchemaServiceTests
     {
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-            _service.ExportSchemaAsync("https://test.crm.dynamics.com", "", "json"));
+            _service.ExportSchemaAsync("", "json"));
 
         Assert.Contains("Output path cannot be null or whitespace", exception.Message);
         Assert.Equal("outputPath", exception.ParamName);
@@ -114,7 +114,7 @@ public class SchemaServiceTests
     {
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-            _service.ExportSchemaAsync("https://test.crm.dynamics.com", "   ", "json"));
+            _service.ExportSchemaAsync("   ", "json"));
 
         Assert.Contains("Output path cannot be null or whitespace", exception.Message);
         Assert.Equal("outputPath", exception.ParamName);
@@ -134,7 +134,7 @@ public class SchemaServiceTests
     {
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-            _service.ExportSchemaAsync("https://test.crm.dynamics.com", "output.file", invalidFormat));
+            _service.ExportSchemaAsync("output.file", invalidFormat));
 
         Assert.Contains("Invalid format", exception.Message);
         Assert.Contains("Supported formats", exception.Message);
@@ -156,7 +156,7 @@ public class SchemaServiceTests
         // Act
         try
         {
-            await _service.ExportSchemaAsync("https://test.crm.dynamics.com", "output.file", format);
+            await _service.ExportSchemaAsync("output.file", format);
             // If we reach here, format was accepted (success)
             Assert.True(true);
         }


### PR DESCRIPTION
## Summary
- Move all Dataverse SDK query/write logic (QueryExpression, SetStateRequest, FetchXML) behind `IDataverseClient` — services no longer construct SDK types directly
- Refactor `ProcessManager` from method-parameter injection to constructor injection for `IDataverseClient`
- Remove dead parameters (`url`, `connectionString`, `clientId`, `clientSecret`) from `SchemaService.ExportSchemaAsync`
- Add 4 new methods to `IDataverseClient`: `RetrieveProcesses`, `ActivateProcess`, `DeactivateProcess`, `RetrieveRecordsByFetchXml`

## Test plan
- [x] `dotnet build` — no errors
- [x] `dotnet test` — all 193 tests pass
- [ ] Optionally run `process-manage` or `refdata-compare` test script against real Dataverse

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)