### PR TITLE
feat: Add N:N relationship comparison to refdata-compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,14 +221,28 @@ powerapps-cli refdata-compare \
       "filter": "<filter><condition attribute='statecode' operator='eq' value='0'/></filter>",
       "excludeFields": ["rob_temporaryfield"]
     }
+  ],
+  "relationships": [
+    {
+      "intersectEntity": "rob_category_priority",
+      "displayName": "Category to Priority",
+      "entity1": "rob_category",
+      "entity1IdField": "rob_categoryid",
+      "entity1NameField": "rob_name",
+      "entity2": "rob_priority",
+      "entity2IdField": "rob_priorityid",
+      "entity2NameField": "rob_priorityname"
+    }
   ]
 }
 ```
 
 **Output**: Excel workbook with:
-- Summary sheet showing all tables and difference counts
+- Summary sheet showing all tables and relationship difference counts
 - Detail sheets for each table with differences (NEW/MODIFIED/DELETED records)
+- Detail sheets for each N:N relationship with differences (NEW/DELETED associations)
 - Field-level comparison using formatted values (human-readable lookups and option sets)
+- GUIDs resolved to display names for relationship associations
 
 ### Process Management
 
@@ -502,6 +516,10 @@ Services/
   ├── ConstantsFilter.cs        # Entity/attribute filtering logic
   ├── IdentifierFormatter.cs    # C# identifier formatting (PascalCase, sanitization)
   ├── MetadataMapper.cs         # SDK to model mapping
+  ├── IRecordComparer.cs        # Record comparison interface
+  ├── RecordComparer.cs         # Record and association comparison logic
+  ├── IComparisonReporter.cs    # Comparison report interface
+  ├── ComparisonReporter.cs     # Comparison report Excel generation
   ├── IProcessManager.cs        # Process management interface
   ├── ProcessManager.cs         # Process state management logic
   └── ProcessReporter.cs        # Process report Excel generation
@@ -517,13 +535,16 @@ Models/
   ├── OptionSetSchema.cs        # OptionSet metadata
   ├── ConstantsConfig.cs        # Constants generation configuration
   ├── ConstantsOutputConfig.cs  # Constants output settings
+  ├── RefDataCompareConfig.cs   # Reference data comparison configuration
+  ├── ComparisonResult.cs       # Table comparison result models
+  ├── RelationshipComparisonResult.cs # N:N relationship comparison models
   ├── ProcessManageConfig.cs    # Process management configuration
   └── ProcessManageModels.cs    # Process state models
 ```
 
 ## Testing
 
-The project includes unit tests covering both schema extraction and constants generation.
+The project includes unit tests covering schema extraction, constants generation, reference data comparison, and process management.
 
 ### Run Tests
 
@@ -544,7 +565,7 @@ reportgenerator -reports:"tests/PowerApps.CLI.Tests/TestResults/coverage.cobertu
 ```
 
 Current test coverage:
-- **246 passing tests** (100% pass rate)
+- **258 passing tests** (100% pass rate)
 - Line coverage: 60%+
 - Branch coverage: 55%+
 
@@ -557,6 +578,7 @@ Test coverage includes:
 - ✅ Metadata mapping
 - ✅ Model validation
 - ✅ Command orchestration (all 4 commands)
+- ✅ Reference data comparison (table records, N:N relationships, name resolution)
 - ✅ Process management (pattern matching, retry logic, state determination)
 
 ## Development

--- a/src/PowerApps.CLI/Models/ComparisonResult.cs
+++ b/src/PowerApps.CLI/Models/ComparisonResult.cs
@@ -26,7 +26,14 @@ public class ComparisonResult
     public List<TableComparisonResult> TableResults { get; set; } = new();
 
     /// <summary>
-    /// Whether any differences were found across all tables.
+    /// Results for each N:N relationship compared.
     /// </summary>
-    public bool HasAnyDifferences => TableResults.Any(t => t.HasDifferences);
+    public List<RelationshipComparisonResult> RelationshipResults { get; set; } = new();
+
+    /// <summary>
+    /// Whether any differences were found across all tables and relationships.
+    /// </summary>
+    public bool HasAnyDifferences =>
+        TableResults.Any(t => t.HasDifferences) ||
+        RelationshipResults.Any(r => r.HasDifferences);
 }

--- a/src/PowerApps.CLI/Models/RefDataCompareConfig.cs
+++ b/src/PowerApps.CLI/Models/RefDataCompareConfig.cs
@@ -19,6 +19,11 @@ public class RefDataCompareConfig
     /// Tables to compare.
     /// </summary>
     public List<RefDataTableConfig> Tables { get; set; } = new();
+
+    /// <summary>
+    /// N:N relationships to compare.
+    /// </summary>
+    public List<RefDataRelationshipConfig> Relationships { get; set; } = new();
 }
 
 /// <summary>
@@ -57,4 +62,50 @@ public class RefDataTableConfig
     /// Additional field names to exclude for this specific table.
     /// </summary>
     public List<string> ExcludeFields { get; set; } = new();
+}
+
+/// <summary>
+/// Configuration for a single N:N relationship comparison.
+/// </summary>
+public class RefDataRelationshipConfig
+{
+    /// <summary>
+    /// The intersect entity logical name (e.g., "contactleads").
+    /// </summary>
+    public string IntersectEntity { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Display name for the relationship (used in report sheet tab).
+    /// </summary>
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// Logical name of the first related entity (e.g., "contact").
+    /// </summary>
+    public string Entity1 { get; set; } = string.Empty;
+
+    /// <summary>
+    /// ID column name for entity1 in the intersect entity (e.g., "contactid").
+    /// </summary>
+    public string Entity1IdField { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Primary name field for entity1 display resolution (e.g., "fullname").
+    /// </summary>
+    public string? Entity1NameField { get; set; } = "name";
+
+    /// <summary>
+    /// Logical name of the second related entity (e.g., "lead").
+    /// </summary>
+    public string Entity2 { get; set; } = string.Empty;
+
+    /// <summary>
+    /// ID column name for entity2 in the intersect entity (e.g., "leadid").
+    /// </summary>
+    public string Entity2IdField { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Primary name field for entity2 display resolution (e.g., "fullname").
+    /// </summary>
+    public string? Entity2NameField { get; set; } = "name";
 }

--- a/src/PowerApps.CLI/Models/RelationshipComparisonResult.cs
+++ b/src/PowerApps.CLI/Models/RelationshipComparisonResult.cs
@@ -1,0 +1,78 @@
+namespace PowerApps.CLI.Models;
+
+/// <summary>
+/// Results for a single N:N relationship comparison.
+/// </summary>
+public class RelationshipComparisonResult
+{
+    /// <summary>
+    /// Display name for the relationship.
+    /// </summary>
+    public string RelationshipName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Intersect entity logical name.
+    /// </summary>
+    public string IntersectEntity { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Total associations in source environment.
+    /// </summary>
+    public int SourceAssociationCount { get; set; }
+
+    /// <summary>
+    /// Total associations in target environment.
+    /// </summary>
+    public int TargetAssociationCount { get; set; }
+
+    /// <summary>
+    /// All association differences found.
+    /// </summary>
+    public List<AssociationDifference> Differences { get; set; } = new();
+
+    /// <summary>
+    /// Count of associations only in source (needs deployment).
+    /// </summary>
+    public int NewCount => Differences.Count(d => d.DifferenceType == DifferenceType.New);
+
+    /// <summary>
+    /// Count of associations only in target (orphaned).
+    /// </summary>
+    public int DeletedCount => Differences.Count(d => d.DifferenceType == DifferenceType.Deleted);
+
+    /// <summary>
+    /// Whether this relationship has any differences.
+    /// </summary>
+    public bool HasDifferences => Differences.Count > 0;
+}
+
+/// <summary>
+/// Represents a difference in a single N:N association.
+/// </summary>
+public class AssociationDifference
+{
+    /// <summary>
+    /// ID of the first related entity record.
+    /// </summary>
+    public Guid Entity1Id { get; set; }
+
+    /// <summary>
+    /// Display name of the first related entity record.
+    /// </summary>
+    public string? Entity1Name { get; set; }
+
+    /// <summary>
+    /// ID of the second related entity record.
+    /// </summary>
+    public Guid Entity2Id { get; set; }
+
+    /// <summary>
+    /// Display name of the second related entity record.
+    /// </summary>
+    public string? Entity2Name { get; set; }
+
+    /// <summary>
+    /// Type of difference (New or Deleted only — associations cannot be Modified).
+    /// </summary>
+    public DifferenceType DifferenceType { get; set; }
+}

--- a/src/PowerApps.CLI/Services/ComparisonReporter.cs
+++ b/src/PowerApps.CLI/Services/ComparisonReporter.cs
@@ -34,6 +34,17 @@ public class ComparisonReporter : IComparisonReporter
             AddTableDetailSheet(workbook, tableResult);
         }
 
+        // Add detail sheets for relationships with differences, sorted alphabetically
+        var sortedRelResults = result.RelationshipResults
+            .Where(r => r.HasDifferences)
+            .OrderBy(r => r.RelationshipName)
+            .ToList();
+
+        foreach (var relResult in sortedRelResults)
+        {
+            AddRelationshipDetailSheet(workbook, relResult);
+        }
+
         // Save workbook
         using var stream = new MemoryStream();
         workbook.SaveAs(stream);
@@ -62,62 +73,122 @@ public class ComparisonReporter : IComparisonReporter
 
         if (!result.HasAnyDifferences)
         {
-            worksheet.Cell(row, 1).Value = "No differences found - all tables are in sync.";
+            worksheet.Cell(row, 1).Value = "No differences found - all tables and relationships are in sync.";
             worksheet.Cell(row, 1).Style.Font.Bold = true;
             worksheet.Cell(row, 1).Style.Font.FontColor = XLColor.Green;
         }
         else
         {
-            // Table summary header
-            worksheet.Cell(row, 1).Value = "Table";
-            worksheet.Cell(row, 2).Value = "Source Count";
-            worksheet.Cell(row, 3).Value = "Target Count";
-            worksheet.Cell(row, 4).Value = "New";
-            worksheet.Cell(row, 5).Value = "Modified";
-            worksheet.Cell(row, 6).Value = "Deleted";
-            worksheet.Cell(row, 7).Value = "Status";
-
-            var headerRow = worksheet.Range(row, 1, row, 7);
-            headerRow.Style.Font.Bold = true;
-            headerRow.Style.Border.BottomBorder = XLBorderStyleValues.Thin;
-
-            row++;
-
-            // Table data
-            foreach (var tableResult in result.TableResults.OrderBy(t => t.TableName))
+            // Table summary section
+            if (result.TableResults.Count > 0)
             {
-                worksheet.Cell(row, 1).Value = tableResult.TableName;
-                worksheet.Cell(row, 2).Value = tableResult.SourceRecordCount;
-                worksheet.Cell(row, 3).Value = tableResult.TargetRecordCount;
-                worksheet.Cell(row, 4).Value = tableResult.NewCount;
-                worksheet.Cell(row, 5).Value = tableResult.ModifiedCount;
-                worksheet.Cell(row, 6).Value = tableResult.DeletedCount;
-                
-                var status = tableResult.HasDifferences ? "Differences Found" : "In Sync";
-                worksheet.Cell(row, 7).Value = status;
-                
-                if (tableResult.HasDifferences)
-                {
-                    worksheet.Cell(row, 7).Style.Font.FontColor = XLColor.Red;
-                    
-                    // Create hyperlink to detail sheet
-                    var detailSheetName = SanitizeSheetName(tableResult.TableName);
-                    worksheet.Cell(row, 1).SetHyperlink(new XLHyperlink($"'{detailSheetName}'!A1"));
-                    worksheet.Cell(row, 1).Style.Font.FontColor = XLColor.Blue;
-                    worksheet.Cell(row, 1).Style.Font.Underline = XLFontUnderlineValues.Single;
-                }
-                else
-                {
-                    worksheet.Cell(row, 7).Style.Font.FontColor = XLColor.Green;
-                }
+                worksheet.Cell(row, 1).Value = "Table Comparisons";
+                worksheet.Cell(row, 1).Style.Font.Bold = true;
+                worksheet.Cell(row, 1).Style.Font.FontSize = 11;
+                row++;
+
+                worksheet.Cell(row, 1).Value = "Table";
+                worksheet.Cell(row, 2).Value = "Source Count";
+                worksheet.Cell(row, 3).Value = "Target Count";
+                worksheet.Cell(row, 4).Value = "New";
+                worksheet.Cell(row, 5).Value = "Modified";
+                worksheet.Cell(row, 6).Value = "Deleted";
+                worksheet.Cell(row, 7).Value = "Status";
+
+                var headerRow = worksheet.Range(row, 1, row, 7);
+                headerRow.Style.Font.Bold = true;
+                headerRow.Style.Border.BottomBorder = XLBorderStyleValues.Thin;
 
                 row++;
+
+                foreach (var tableResult in result.TableResults.OrderBy(t => t.TableName))
+                {
+                    worksheet.Cell(row, 1).Value = tableResult.TableName;
+                    worksheet.Cell(row, 2).Value = tableResult.SourceRecordCount;
+                    worksheet.Cell(row, 3).Value = tableResult.TargetRecordCount;
+                    worksheet.Cell(row, 4).Value = tableResult.NewCount;
+                    worksheet.Cell(row, 5).Value = tableResult.ModifiedCount;
+                    worksheet.Cell(row, 6).Value = tableResult.DeletedCount;
+
+                    var status = tableResult.HasDifferences ? "Differences Found" : "In Sync";
+                    worksheet.Cell(row, 7).Value = status;
+
+                    if (tableResult.HasDifferences)
+                    {
+                        worksheet.Cell(row, 7).Style.Font.FontColor = XLColor.Red;
+
+                        var detailSheetName = SanitizeSheetName(tableResult.TableName);
+                        worksheet.Cell(row, 1).SetHyperlink(new XLHyperlink($"'{detailSheetName}'!A1"));
+                        worksheet.Cell(row, 1).Style.Font.FontColor = XLColor.Blue;
+                        worksheet.Cell(row, 1).Style.Font.Underline = XLFontUnderlineValues.Single;
+                    }
+                    else
+                    {
+                        worksheet.Cell(row, 7).Style.Font.FontColor = XLColor.Green;
+                    }
+
+                    row++;
+                }
+
+                var tableRange = worksheet.Range(row - result.TableResults.Count - 1, 1, row - 1, 7);
+                var excelTable = tableRange.CreateTable("TableComparisons");
+                excelTable.Theme = XLTableTheme.TableStyleLight9;
             }
 
-            // Create Excel table
-            var tableRange = worksheet.Range(row - result.TableResults.Count - 1, 1, row - 1, 7);
-            var excelTable = tableRange.CreateTable();
-            excelTable.Theme = XLTableTheme.TableStyleLight9;
+            // Relationship summary section
+            if (result.RelationshipResults.Count > 0)
+            {
+                row++; // Blank row
+                worksheet.Cell(row, 1).Value = "Relationship Comparisons";
+                worksheet.Cell(row, 1).Style.Font.Bold = true;
+                worksheet.Cell(row, 1).Style.Font.FontSize = 11;
+                row++;
+
+                worksheet.Cell(row, 1).Value = "Relationship";
+                worksheet.Cell(row, 2).Value = "Source Count";
+                worksheet.Cell(row, 3).Value = "Target Count";
+                worksheet.Cell(row, 4).Value = "New";
+                worksheet.Cell(row, 5).Value = "Deleted";
+                worksheet.Cell(row, 6).Value = "Status";
+
+                var relHeaderRow = worksheet.Range(row, 1, row, 6);
+                relHeaderRow.Style.Font.Bold = true;
+                relHeaderRow.Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+
+                row++;
+
+                foreach (var relResult in result.RelationshipResults.OrderBy(r => r.RelationshipName))
+                {
+                    worksheet.Cell(row, 1).Value = relResult.RelationshipName;
+                    worksheet.Cell(row, 2).Value = relResult.SourceAssociationCount;
+                    worksheet.Cell(row, 3).Value = relResult.TargetAssociationCount;
+                    worksheet.Cell(row, 4).Value = relResult.NewCount;
+                    worksheet.Cell(row, 5).Value = relResult.DeletedCount;
+
+                    var status = relResult.HasDifferences ? "Differences Found" : "In Sync";
+                    worksheet.Cell(row, 6).Value = status;
+
+                    if (relResult.HasDifferences)
+                    {
+                        worksheet.Cell(row, 6).Style.Font.FontColor = XLColor.Red;
+
+                        var detailSheetName = SanitizeSheetName(relResult.RelationshipName);
+                        worksheet.Cell(row, 1).SetHyperlink(new XLHyperlink($"'{detailSheetName}'!A1"));
+                        worksheet.Cell(row, 1).Style.Font.FontColor = XLColor.Blue;
+                        worksheet.Cell(row, 1).Style.Font.Underline = XLFontUnderlineValues.Single;
+                    }
+                    else
+                    {
+                        worksheet.Cell(row, 6).Style.Font.FontColor = XLColor.Green;
+                    }
+
+                    row++;
+                }
+
+                var relTableRange = worksheet.Range(row - result.RelationshipResults.Count - 1, 1, row - 1, 6);
+                var relExcelTable = relTableRange.CreateTable("RelationshipComparisons");
+                relExcelTable.Theme = XLTableTheme.TableStyleLight9;
+            }
         }
 
         // Auto-fit columns
@@ -189,6 +260,65 @@ public class ComparisonReporter : IComparisonReporter
         if (row > startRow)
         {
             var tableRange = worksheet.Range(startRow - 1, 1, row - 1, 6);
+            var excelTable = tableRange.CreateTable();
+            excelTable.Theme = XLTableTheme.TableStyleLight9;
+        }
+
+        // Auto-fit columns
+        worksheet.Columns().AdjustToContents();
+    }
+
+    private void AddRelationshipDetailSheet(XLWorkbook workbook, RelationshipComparisonResult relResult)
+    {
+        var sheetName = SanitizeSheetName(relResult.RelationshipName);
+        var worksheet = workbook.Worksheets.Add(sheetName);
+
+        // Header
+        worksheet.Cell(1, 1).Value = $"{relResult.RelationshipName} - Differences";
+        worksheet.Cell(1, 1).Style.Font.Bold = true;
+        worksheet.Cell(1, 1).Style.Font.FontSize = 12;
+
+        // Summary
+        var row = 3;
+        worksheet.Cell(row++, 1).Value = $"Intersect Entity: {relResult.IntersectEntity}";
+        worksheet.Cell(row++, 1).Value = $"Total Source: {relResult.SourceAssociationCount}";
+        worksheet.Cell(row++, 1).Value = $"Total Target: {relResult.TargetAssociationCount}";
+        worksheet.Cell(row++, 1).Value = $"New: {relResult.NewCount}, Deleted: {relResult.DeletedCount}";
+
+        row++; // Blank row
+
+        // Detail table header
+        worksheet.Cell(row, 1).Value = "Entity 1 Name";
+        worksheet.Cell(row, 2).Value = "Entity 1 ID";
+        worksheet.Cell(row, 3).Value = "Entity 2 Name";
+        worksheet.Cell(row, 4).Value = "Entity 2 ID";
+        worksheet.Cell(row, 5).Value = "Status";
+
+        var headerRow = worksheet.Range(row, 1, row, 5);
+        headerRow.Style.Font.Bold = true;
+        headerRow.Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+
+        row++;
+        var startRow = row;
+
+        // Detail data
+        foreach (var diff in relResult.Differences
+            .OrderBy(d => d.DifferenceType)
+            .ThenBy(d => d.Entity1Name)
+            .ThenBy(d => d.Entity2Name))
+        {
+            worksheet.Cell(row, 1).Value = diff.Entity1Name ?? diff.Entity1Id.ToString();
+            worksheet.Cell(row, 2).Value = diff.Entity1Id.ToString();
+            worksheet.Cell(row, 3).Value = diff.Entity2Name ?? diff.Entity2Id.ToString();
+            worksheet.Cell(row, 4).Value = diff.Entity2Id.ToString();
+            worksheet.Cell(row, 5).Value = diff.DifferenceType.ToString();
+            row++;
+        }
+
+        // Create Excel table
+        if (row > startRow)
+        {
+            var tableRange = worksheet.Range(startRow - 1, 1, row - 1, 5);
             var excelTable = tableRange.CreateTable();
             excelTable.Theme = XLTableTheme.TableStyleLight9;
         }

--- a/src/PowerApps.CLI/Services/IRecordComparer.cs
+++ b/src/PowerApps.CLI/Services/IRecordComparer.cs
@@ -25,4 +25,24 @@ public interface IRecordComparer
         HashSet<string> excludeFields,
         string? primaryNameField = null,
         string? primaryIdField = null);
+
+    /// <summary>
+    /// Compares N:N associations between source and target environments.
+    /// </summary>
+    /// <param name="relationshipName">Display name for the relationship.</param>
+    /// <param name="sourceAssociations">Association records from source environment.</param>
+    /// <param name="targetAssociations">Association records from target environment.</param>
+    /// <param name="entity1IdField">ID column name for entity1 in the intersect entity.</param>
+    /// <param name="entity2IdField">ID column name for entity2 in the intersect entity.</param>
+    /// <param name="entity1Names">Lookup dictionary mapping entity1 IDs to display names.</param>
+    /// <param name="entity2Names">Lookup dictionary mapping entity2 IDs to display names.</param>
+    /// <returns>Comparison result with association differences.</returns>
+    RelationshipComparisonResult CompareAssociations(
+        string relationshipName,
+        EntityCollection sourceAssociations,
+        EntityCollection targetAssociations,
+        string entity1IdField,
+        string entity2IdField,
+        Dictionary<Guid, string> entity1Names,
+        Dictionary<Guid, string> entity2Names);
 }

--- a/tests/PowerApps.CLI.Tests/Services/ComparisonReporterTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/ComparisonReporterTests.cs
@@ -111,7 +111,7 @@ public class ComparisonReporterTests : IDisposable
                             {
                                 new FieldDifference
                                 {
-                                    FieldName = "anc_name",
+                                    FieldName = "rob_name",
                                     SourceValue = "Female2",
                                     TargetValue = "Female"
                                 }

--- a/tests/scripts/refdata-compare/sample-config.json
+++ b/tests/scripts/refdata-compare/sample-config.json
@@ -17,14 +17,7 @@
       "primaryNameField": "fullname",
       "filter": "",
       "excludeFields": ["address1_addressid", "address2_addressid", "address3_addressid"]
-    },
-    {
-      "logicalName": "queue",
-      "displayName": "Queue",
-      "primaryIdField": "queueid",
-      "primaryNameField": "name",
-      "filter": "",
-      "excludeFields": ["numberofitems", "organizationid"]
     }
-  ]
+  ],
+  "relationships": []
 }


### PR DESCRIPTION
## Summary
- Adds N:N (many-to-many) relationship association comparison to the `refdata-compare` command
- Compares associations by composite key `(entity1id, entity2id)` — reports New (in source only) and Deleted (in target only)
- Resolves GUIDs to display names via configurable `entity1NameField`/`entity2NameField` with GUID fallback
- Excel report includes relationship summary rows on the Summary sheet and detail sheets per relationship with differences

## Changes
- **Config**: New `relationships` array in config with `intersectEntity`, `displayName`, entity1/entity2 fields
- **Models**: `RelationshipComparisonResult`, `AssociationDifference`, updated `ComparisonResult`
- **Services**: `CompareAssociations` + `BuildNameLookup` on `RecordComparer`, relationship sheets in `ComparisonReporter`
- **Command**: Orchestration loop for relationship comparison with name resolution
- **Tests**: 12 new tests (8 CompareAssociations, 2 BuildNameLookup, 3 command orchestration) — 258 total passing

## Test plan
- [x] `dotnet build` — no errors
- [x] `dotnet test` — all 258 tests pass
- [x] Integration tested with real N:N relationship (SR Activity to Stage) — verified name resolution works
- [x] Verified GUID fallback when name fields not configured
- [x] No `anc_` references or credentials in committed code

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)