### PR TITLE
feat: Add duplicate detection rule support to process-manage

### DIFF
--- a/src/PowerApps.CLI/Infrastructure/IDataverseClient.cs
+++ b/src/PowerApps.CLI/Infrastructure/IDataverseClient.cs
@@ -85,6 +85,25 @@ public interface IDataverseClient
     void DeactivateProcess(Guid processId);
 
     /// <summary>
+    /// Retrieves duplicate detection rules, optionally filtered by solution names.
+    /// </summary>
+    /// <param name="solutions">Solution unique names to filter by. If empty, retrieves all rules.</param>
+    /// <returns>Collection of duplicaterule entities.</returns>
+    EntityCollection RetrieveDuplicateRules(List<string> solutions);
+
+    /// <summary>
+    /// Publishes (activates) a duplicate detection rule.
+    /// </summary>
+    /// <param name="ruleId">The ID of the duplicate detection rule to activate.</param>
+    void ActivateDuplicateRule(Guid ruleId);
+
+    /// <summary>
+    /// Unpublishes (deactivates) a duplicate detection rule.
+    /// </summary>
+    /// <param name="ruleId">The ID of the duplicate detection rule to deactivate.</param>
+    void DeactivateDuplicateRule(Guid ruleId);
+
+    /// <summary>
     /// Retrieves records using a FetchXML query.
     /// </summary>
     /// <param name="fetchXml">The FetchXML query string.</param>

--- a/src/PowerApps.CLI/Models/ProcessManageModels.cs
+++ b/src/PowerApps.CLI/Models/ProcessManageModels.cs
@@ -22,7 +22,8 @@ public enum ProcessType
     BusinessRule = 2,
     Action = 3,
     BusinessProcessFlow = 4,
-    CloudFlow = 5
+    CloudFlow = 5,
+    DuplicateDetectionRule = 100
 }
 
 /// <summary>

--- a/src/PowerApps.CLI/Services/ProcessReporter.cs
+++ b/src/PowerApps.CLI/Services/ProcessReporter.cs
@@ -118,7 +118,9 @@ public class ProcessReporter : IProcessReporter
             ProcessType.Workflow => "Workflow",
             ProcessType.BusinessRule => "Business Rule",
             ProcessType.Action => "Action",
+            ProcessType.BusinessProcessFlow => "Business Process Flow",
             ProcessType.CloudFlow => "Cloud Flow",
+            ProcessType.DuplicateDetectionRule => "Duplicate Detection Rule",
             _ => "Unknown"
         };
     }


### PR DESCRIPTION
## Summary
- Adds duplicate detection rules as a new process type (`DuplicateDetectionRule = 100`) managed by the `process-manage` command
- Extends `IDataverseClient` / `DataverseClient` with `RetrieveDuplicateRules`, `ActivateDuplicateRule`, and `DeactivateDuplicateRule` methods
- Routes activation via `PublishDuplicateRuleRequest` and deactivation via `SetStateRequest` to match Dataverse SDK conventions
- Adds 6 new unit tests covering retrieval, deduplication, state mapping, and correct client method routing
- Also fixes missing `BusinessProcessFlow` mapping in the process reporter

Closes #28

## Test plan
- [x] All 264 tests pass (including 6 new duplicate detection rule tests)
- [x] Build succeeds with 0 warnings
- [ ] Manual verification against a Dataverse environment with duplicate detection rules in a solution

🤖 Generated with [Claude Code](https://claude.com/claude-code)