### PR TITLE
fix: emit statecode/statuscode field name constants in constants-generate

### DIFF
--- a/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
+++ b/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
@@ -57,12 +57,10 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
 
         // Attributes — seed used names with className to prevent CS0542
         var usedAttributeNames = new HashSet<string> { className };
+
         foreach (var attr in entity.Attributes)
         {
-            if (attr.OptionSet == null || !IsStateOrStatusCode(attr.AttributeType))
-            {
-                AppendAttributeConstant(sb, attr, usedAttributeNames);
-            }
+            AppendAttributeConstant(sb, attr, usedAttributeNames);
         }
 
         // State/Status codes
@@ -150,7 +148,7 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
         if (stateCodeAttr?.OptionSet != null && stateCodeAttr.OptionSet.Options.Count > 0)
         {
             AppendComment(sb, 8, $"State Code options for {entity.DisplayName ?? entity.LogicalName}.");
-            sb.AppendLine("        public static class StateCode");
+            sb.AppendLine("        public static class StateCodeOptions");
             sb.AppendLine("        {");
 
             var usedStateCodeNames = new HashSet<string>();
@@ -168,7 +166,7 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
         if (statusCodeAttr?.OptionSet != null && statusCodeAttr.OptionSet.Options.Count > 0)
         {
             AppendComment(sb, 8, $"Status Code options for {entity.DisplayName ?? entity.LogicalName}.");
-            sb.AppendLine("        public static class StatusCode");
+            sb.AppendLine("        public static class StatusCodeOptions");
             sb.AppendLine("        {");
 
             var usedStatusCodeNames = new HashSet<string>();


### PR DESCRIPTION
Closes #47

## Summary

- `statecode` and `statuscode` field name constants were not being emitted during `constants-generate` — the attribute loop incorrectly skipped them to avoid a `CS0102` conflict with the nested `StateCode`/`StatusCode` option value classes
- Removed the condition that excluded State/Status attributes from the field constant loop, so all attributes now get a field name constant
- Renamed the nested option value classes from `StateCode`/`StatusCode` to `StateCodeOptions`/`StatusCodeOptions` to eliminate the naming conflict

**Before:**
```csharp
// statecode / statuscode field constants were missing entirely
public static class StateCode { ... }
public static class StatusCode { ... }
```

**After:**
```csharp
public const string StateCode = "statecode";
public const string StatusCode = "statuscode";

public static class StateCodeOptions { ... }
public static class StatusCodeOptions { ... }
```

## Test plan

- [ ] Run `constants-generate` against an entity with statecode/statuscode and verify both field constants appear
- [ ] Verify the nested option value classes are now named `StateCodeOptions` / `StatusCodeOptions`
- [ ] Confirm generated output compiles without CS0102 or CS0542 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)