### PR TITLE
fix: emit statecode/statuscode field constants and rename nested classes to Options suffix

### DIFF
--- a/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
+++ b/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
@@ -55,14 +55,11 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
             sb.AppendLine();
         }
 
-        // Attributes — seed used names with className to prevent CS0542
-        var usedAttributeNames = new HashSet<string> { className };
+        // Attributes — seed used names with className to prevent CS0542, and with nested class names to prevent member name conflicts
+        var usedAttributeNames = new HashSet<string> { className, "StateCodeOptions", "StatusCodeOptions" };
         foreach (var attr in entity.Attributes)
         {
-            if (attr.OptionSet == null || !IsStateOrStatusCode(attr.AttributeType))
-            {
-                AppendAttributeConstant(sb, attr, usedAttributeNames);
-            }
+            AppendAttributeConstant(sb, attr, usedAttributeNames);
         }
 
         // State/Status codes
@@ -150,7 +147,7 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
         if (stateCodeAttr?.OptionSet != null && stateCodeAttr.OptionSet.Options.Count > 0)
         {
             AppendComment(sb, 8, $"State Code options for {entity.DisplayName ?? entity.LogicalName}.");
-            sb.AppendLine("        public static class StateCode");
+            sb.AppendLine("        public static class StateCodeOptions");
             sb.AppendLine("        {");
 
             var usedStateCodeNames = new HashSet<string>();
@@ -168,7 +165,7 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
         if (statusCodeAttr?.OptionSet != null && statusCodeAttr.OptionSet.Options.Count > 0)
         {
             AppendComment(sb, 8, $"Status Code options for {entity.DisplayName ?? entity.LogicalName}.");
-            sb.AppendLine("        public static class StatusCode");
+            sb.AppendLine("        public static class StatusCodeOptions");
             sb.AppendLine("        {");
 
             var usedStatusCodeNames = new HashSet<string>();

--- a/tests/PowerApps.CLI.Tests/Services/CodeTemplateGeneratorTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/CodeTemplateGeneratorTests.cs
@@ -78,6 +78,7 @@ public class CodeTemplateGeneratorTests
                 new AttributeSchema
                 {
                     LogicalName = "statecode",
+                    DisplayName = "State Code",
                     AttributeType = "State",
                     OptionSet = new OptionSetSchema
                     {
@@ -96,7 +97,8 @@ public class CodeTemplateGeneratorTests
         var result = generator.GenerateEntityClass(entity, "MyCompany.Constants");
 
         // Assert
-        Assert.Contains("public static class StateCode", result);
+        Assert.Contains("public const string StateCode = \"statecode\";", result);
+        Assert.Contains("public static class StateCodeOptions", result);
         Assert.Contains("public const int Active = 0;", result);
         Assert.Contains("public const int Inactive = 1;", result);
     }
@@ -116,6 +118,7 @@ public class CodeTemplateGeneratorTests
                 new AttributeSchema
                 {
                     LogicalName = "statuscode",
+                    DisplayName = "Status Code",
                     AttributeType = "Status",
                     OptionSet = new OptionSetSchema
                     {
@@ -134,7 +137,8 @@ public class CodeTemplateGeneratorTests
         var result = generator.GenerateEntityClass(entity, "MyCompany.Constants");
 
         // Assert
-        Assert.Contains("public static class StatusCode", result);
+        Assert.Contains("public const string StatusCode = \"statuscode\";", result);
+        Assert.Contains("public static class StatusCodeOptions", result);
         Assert.Contains("public const int Active = 1;", result);
         Assert.Contains("public const int Inactive = 2;", result);
     }


### PR DESCRIPTION
## Summary

- Emit `statecode` and `statuscode` as field constants (alongside their nested option classes) instead of skipping them
- Rename nested `StateCode` → `StateCodeOptions` and `StatusCode` → `StatusCodeOptions` to avoid member name conflicts with the new field constants
- Seed `usedAttributeNames` with the nested class names (`StateCodeOptions`, `StatusCodeOptions`) to prevent CS0102 compiler errors

## Test plan

- [ ] Verify `public const string StateCode = "statecode";` is emitted in generated output
- [ ] Verify `public const string StatusCode = "statuscode";` is emitted in generated output
- [ ] Verify nested classes are named `StateCodeOptions` / `StatusCodeOptions` in generated output
- [ ] Run existing unit tests — both `StateCode` and `StatusCode` test assertions updated to match new behaviour
- [ ] Build solution and confirm no CS0542 or CS0102 compiler errors in generated constants files

🤖 Generated with [Claude Code](https://claude.com/claude-code)