### PR TITLE
fix: prevent CS0542/CS0102 clashes in constants-generate output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ bld/
 [Bb]uild[Ll]og.*
 
 # Code Coverage
+coverage/
 tests/coverage/
 *.coverage
 *.coveragexml

--- a/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
+++ b/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
@@ -91,7 +91,7 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
         sb.AppendLine($"    public static class {className}");
         sb.AppendLine("    {");
 
-        var usedOptionNames = new HashSet<string>();
+        var usedOptionNames = new HashSet<string> { className };
         foreach (var option in optionSet.Options)
         {
             AppendOptionConstant(sb, option, 8, usedOptionNames);

--- a/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
+++ b/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
@@ -187,11 +187,15 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
                         !IsStateOrStatusCode(a.AttributeType))
             .ToList();
 
+        var usedClassNames = new HashSet<string>();
         foreach (var attr in localOptionSetAttrs)
         {
             if (attr.OptionSet == null) continue;
 
-            var className = _formatter.ToIdentifier(attr.DisplayName ?? attr.LogicalName) + "Options";
+            var className = _formatter.MakeUnique(
+                _formatter.ToIdentifier(attr.DisplayName ?? attr.LogicalName) + "Options",
+                usedClassNames, "_");
+            usedClassNames.Add(className);
 
             AppendComment(sb, 8, $"{attr.DisplayName ?? attr.LogicalName} option set values.");
             sb.AppendLine($"        public static class {className}");

--- a/tests/PowerApps.CLI.Tests/Services/CodeTemplateGeneratorTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/CodeTemplateGeneratorTests.cs
@@ -185,6 +185,60 @@ public class CodeTemplateGeneratorTests
     }
 
     [Fact]
+    public void GenerateEntityClass_TwoLocalOptionSetsWithSamePascalCasedName_DeduplicatesCS0102()
+    {
+        // Arrange — two attributes with the same display name both resolve to FavouriteColourOptions
+        var formatter = new IdentifierFormatter();
+        var generator = new CodeTemplateGenerator(includeComments: false, includeRelationships: false, formatter);
+        var entity = new EntitySchema
+        {
+            LogicalName = "sample_entity",
+            DisplayName = "Sample Entity",
+            Attributes = new List<AttributeSchema>
+            {
+                new AttributeSchema
+                {
+                    LogicalName = "favouritecolourcode",
+                    DisplayName = "Favourite Colour",
+                    AttributeType = "Picklist",
+                    OptionSet = new OptionSetSchema
+                    {
+                        IsGlobal = false,
+                        Options = new List<OptionSchema>
+                        {
+                            new OptionSchema { Value = 1, Label = "Red" }
+                        }
+                    }
+                },
+                new AttributeSchema
+                {
+                    LogicalName = "rob_favouritecolourcode",
+                    DisplayName = "Favourite Colour",
+                    AttributeType = "Picklist",
+                    OptionSet = new OptionSetSchema
+                    {
+                        IsGlobal = false,
+                        Options = new List<OptionSchema>
+                        {
+                            new OptionSchema { Value = 1, Label = "Blue" }
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var result = generator.GenerateEntityClass(entity, "MyCompany.Constants");
+
+        // Assert — first class keeps the original name, second is renamed to avoid CS0102
+        Assert.Contains("public static class FavouriteColourOptions", result);
+        Assert.Contains("public static class FavouriteColourOptions_", result); // second gets disambiguated suffix
+        // Both option values must be present (proving both classes were emitted)
+        Assert.Contains("public const int Red = 1;", result);
+        Assert.Contains("public const int Blue = 1;", result);
+    }
+
+    [Fact]
     public void GenerateEntityClass_WithCommentsDisabled_DoesNotGenerateComments()
     {
         // Arrange

--- a/tests/PowerApps.CLI.Tests/Services/CodeTemplateGeneratorTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/CodeTemplateGeneratorTests.cs
@@ -241,6 +241,32 @@ public class CodeTemplateGeneratorTests
     }
 
     [Fact]
+    public void GenerateGlobalOptionSetClass_OptionLabelMatchesClassName_DeduplicatesCS0542()
+    {
+        // Arrange — global option set "day" with an option also called "Day" would cause CS0542
+        var formatter = new IdentifierFormatter();
+        var generator = new CodeTemplateGenerator(includeComments: true, includeRelationships: true, formatter);
+        var optionSet = new OptionSetSchema
+        {
+            Name = "day",
+            IsGlobal = true,
+            Options = new List<OptionSchema>
+            {
+                new OptionSchema { Value = 1, Label = "Day" },
+                new OptionSchema { Value = 2, Label = "Night" }
+            }
+        };
+
+        // Act
+        var result = generator.GenerateGlobalOptionSetClass(optionSet, "MyCompany.Constants");
+
+        // Assert — "Day" constant must be renamed to avoid CS0542 clash with class "Day"
+        Assert.Contains("public static class Day", result);
+        Assert.DoesNotContain("public const int Day = 1;", result);
+        Assert.Contains("public const int Night = 2;", result);
+    }
+
+    [Fact]
     public void GenerateGlobalOptionSetClass_WithSpecialCharacters_SanitisesClassName()
     {
         // Arrange


### PR DESCRIPTION
## Summary

- **CS0542 (global option sets):** Seeds `usedOptionNames` with `className` in `GenerateGlobalOptionSetClass` so an option label matching the enclosing class name is deduplicated via `MakeUnique` — consistent with the same fix applied to entity attributes in #45.
- **CS0102 (local option sets):** Tracks used nested class names per entity in `AppendLocalOptionSets` and calls `MakeUnique` on each, so two attributes with the same display name produce distinct class names instead of a duplicate member error.

Closes #51

## Test plan

- [ ] `GenerateGlobalOptionSetClass_OptionLabelMatchesClassName_DeduplicatesCS0542` — verifies global option set `Day` with option `Day` is renamed
- [ ] `GenerateEntityClass_TwoLocalOptionSetsWithSamePascalCasedName_DeduplicatesCS0102` — verifies two attributes with display name `Favourite Colour` produce `FavouriteColourOptions` and `FavouriteColourOptions_`
- [ ] Full test suite passes (348 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)