### PR TITLE
fix: simplify MakeUnique suffix scheme to _, _1, _2

### DIFF
--- a/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
+++ b/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
@@ -130,7 +130,7 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
         var attributeName = _formatter.ToIdentifier(attr.DisplayName ?? attr.SchemaName ?? attr.LogicalName);
 
         // Deduplicate — also handles CS0542 (class name pre-seeded into usedNames)
-        attributeName = _formatter.MakeUnique(attributeName, usedNames, "_");
+        attributeName = _formatter.MakeUnique(attributeName, usedNames);
         usedNames.Add(attributeName);
 
         var comment = BuildAttributeComment(attr);
@@ -194,7 +194,7 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
 
             var className = _formatter.MakeUnique(
                 _formatter.ToIdentifier(attr.DisplayName ?? attr.LogicalName) + "Options",
-                usedClassNames, "_");
+                usedClassNames);
             usedClassNames.Add(className);
 
             AppendComment(sb, 8, $"{attr.DisplayName ?? attr.LogicalName} option set values.");
@@ -217,7 +217,7 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
         var optionName = _formatter.ToIdentifier(option.Label ?? $"Option{option.Value}");
 
         // Deduplicate using the option value as suffix to keep names meaningful (CS0102)
-        optionName = _formatter.MakeUnique(optionName, usedNames, option.Value.ToString());
+        optionName = _formatter.MakeUnique(optionName, usedNames);
         usedNames.Add(optionName);
 
         var spaces = new string(' ', indent);

--- a/src/PowerApps.CLI/Services/IIdentifierFormatter.cs
+++ b/src/PowerApps.CLI/Services/IIdentifierFormatter.cs
@@ -18,5 +18,5 @@ public interface IIdentifierFormatter
     /// <summary>
     /// Generates a unique identifier when duplicates are found.
     /// </summary>
-    string MakeUnique(string identifier, HashSet<string> existingIdentifiers, string? suffix = null);
+    string MakeUnique(string identifier, HashSet<string> existingIdentifiers);
 }

--- a/src/PowerApps.CLI/Services/IdentifierFormatter.cs
+++ b/src/PowerApps.CLI/Services/IdentifierFormatter.cs
@@ -129,25 +129,23 @@ public class IdentifierFormatter : IIdentifierFormatter
 
     /// <summary>
     /// Generates a unique identifier when duplicates are found.
+    /// First collision appends "_", subsequent collisions append "_1", "_2", etc.
     /// </summary>
-    public string MakeUnique(string identifier, HashSet<string> existingIdentifiers, string? suffix = null)
+    public string MakeUnique(string identifier, HashSet<string> existingIdentifiers)
     {
         if (!existingIdentifiers.Contains(identifier))
             return identifier;
 
-        // Append suffix (e.g., short GUID)
-        var uniqueIdentifier = suffix != null
-            ? $"{identifier}_{suffix}"
-            : $"{identifier}_{Guid.NewGuid().ToString().Substring(0, 6)}";
+        var candidate = $"{identifier}_";
+        if (!existingIdentifiers.Contains(candidate))
+            return candidate;
 
-        // Ensure uniqueness
         int counter = 1;
-        var baseIdentifier = uniqueIdentifier;
-        while (existingIdentifiers.Contains(uniqueIdentifier))
+        while (true)
         {
-            uniqueIdentifier = $"{baseIdentifier}_{counter++}";
+            candidate = $"{identifier}_{counter++}";
+            if (!existingIdentifiers.Contains(candidate))
+                return candidate;
         }
-
-        return uniqueIdentifier;
     }
 }

--- a/tests/PowerApps.CLI.Tests/Services/IdentifierFormatterTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/IdentifierFormatterTests.cs
@@ -264,7 +264,7 @@ public class IdentifierFormatterTests
     }
 
     [Fact]
-    public void MakeUnique_DuplicateIdentifier_AppendsGuid()
+    public void MakeUnique_DuplicateIdentifier_AppendsUnderscore()
     {
         // Arrange
         var formatter = new IdentifierFormatter();
@@ -274,35 +274,34 @@ public class IdentifierFormatterTests
         var result = formatter.MakeUnique("Contact", existingIdentifiers);
 
         // Assert
-        Assert.NotEqual("Contact", result);
-        Assert.StartsWith("Contact_", result);
+        Assert.Equal("Contact_", result);
     }
 
     [Fact]
-    public void MakeUnique_WithCustomSuffix_AppendsCustomSuffix()
+    public void MakeUnique_FirstSuffixTaken_AppendsOne()
     {
         // Arrange
         var formatter = new IdentifierFormatter();
-        var existingIdentifiers = new HashSet<string> { "Contact" };
+        var existingIdentifiers = new HashSet<string> { "Contact", "Contact_" };
 
         // Act
-        var result = formatter.MakeUnique("Contact", existingIdentifiers, "V2");
+        var result = formatter.MakeUnique("Contact", existingIdentifiers);
 
         // Assert
-        Assert.Equal("Contact_V2", result);
+        Assert.Equal("Contact_1", result);
     }
 
     [Fact]
-    public void MakeUnique_MultipleDuplicates_AppendsCounter()
+    public void MakeUnique_MultipleDuplicates_IncrementsCounter()
     {
         // Arrange
         var formatter = new IdentifierFormatter();
-        var existingIdentifiers = new HashSet<string> { "Contact", "Contact_abc123", "Contact_abc123_1" };
+        var existingIdentifiers = new HashSet<string> { "Contact", "Contact_", "Contact_1" };
 
         // Act
-        var result = formatter.MakeUnique("Contact", existingIdentifiers, "abc123");
+        var result = formatter.MakeUnique("Contact", existingIdentifiers);
 
         // Assert
-        Assert.Equal("Contact_abc123_2", result);
+        Assert.Equal("Contact_2", result);
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the `suffix` parameter on `MakeUnique` with a consistent built-in scheme: first collision appends `_`, subsequent collisions append `_1`, `_2`, etc.
- Fixes `CampaignTypeOptions__` (double underscore) and `Day_0` (unintuitive option value suffix) from the previous implementation.
- Updates `IIdentifierFormatter` interface and all three call sites in `CodeTemplateGenerator`.

## Test plan

- [ ] `MakeUnique_DuplicateIdentifier_AppendsUnderscore` — first collision returns `Contact_`
- [ ] `MakeUnique_FirstSuffixTaken_AppendsOne` — second collision returns `Contact_1`
- [ ] `MakeUnique_MultipleDuplicates_IncrementsCounter` — third collision returns `Contact_2`
- [ ] Full test suite passes (348 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)