### PR TITLE
fix: prevent name clash when column display name matches hard-coded entity constants

### DIFF
--- a/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
+++ b/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
@@ -55,8 +55,13 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
             sb.AppendLine();
         }
 
-        // Attributes — seed used names with className to prevent CS0542, and with nested class names to prevent member name conflicts
-        var usedAttributeNames = new HashSet<string> { className, "StateCodeOptions", "StatusCodeOptions" };
+        // Attributes — seed used names with className to prevent CS0542, with nested class names, and with the
+        // hard-coded entity-level constant names so columns like "Entity Logical Name" don't collide
+        var usedAttributeNames = new HashSet<string> { className, "StateCodeOptions", "StatusCodeOptions", "EntityLogicalName" };
+        if (!string.IsNullOrEmpty(entity.PrimaryIdAttribute))
+            usedAttributeNames.Add("PrimaryIdAttribute");
+        if (!string.IsNullOrEmpty(entity.PrimaryNameAttribute))
+            usedAttributeNames.Add("PrimaryNameAttribute");
         foreach (var attr in entity.Attributes)
         {
             AppendAttributeConstant(sb, attr, usedAttributeNames);

--- a/tests/PowerApps.CLI.Tests/Services/CodeTemplateGeneratorTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/CodeTemplateGeneratorTests.cs
@@ -543,4 +543,96 @@ public class CodeTemplateGeneratorTests
         Assert.Contains("public static class PreferredMethodOptions", result);
         Assert.Contains("public static class Address1TypeOptions", result);
     }
+
+    [Fact]
+    public void GenerateEntityClass_ColumnNamedEntityLogicalName_DeduplicatesAgainstHardCodedConstant()
+    {
+        // Arrange — column whose display name formats to EntityLogicalName would duplicate the hard-coded constant
+        var formatter = new IdentifierFormatter();
+        var generator = new CodeTemplateGenerator(includeComments: false, includeRelationships: false, formatter);
+        var entity = new EntitySchema
+        {
+            LogicalName = "sample_table",
+            DisplayName = "Sample Table",
+            Attributes = new List<AttributeSchema>
+            {
+                new AttributeSchema
+                {
+                    LogicalName = "sample_entitylogicalname",
+                    DisplayName = "Entity Logical Name",
+                    AttributeType = "String"
+                }
+            }
+        };
+
+        // Act
+        var result = generator.GenerateEntityClass(entity, "MyCompany.Constants");
+
+        // Assert — hard-coded EntityLogicalName constant is present and the column gets a disambiguated name
+        Assert.Contains("public const string EntityLogicalName = \"sample_table\";", result);
+        Assert.DoesNotContain("public const string EntityLogicalName = \"sample_entitylogicalname\";", result);
+        Assert.Contains("public const string EntityLogicalName_ = \"sample_entitylogicalname\";", result);
+    }
+
+    [Fact]
+    public void GenerateEntityClass_ColumnNamedPrimaryIdAttribute_DeduplicatesAgainstHardCodedConstant()
+    {
+        // Arrange — column whose display name formats to PrimaryIdAttribute would duplicate the hard-coded constant
+        var formatter = new IdentifierFormatter();
+        var generator = new CodeTemplateGenerator(includeComments: false, includeRelationships: false, formatter);
+        var entity = new EntitySchema
+        {
+            LogicalName = "sample_table",
+            DisplayName = "Sample Table",
+            PrimaryIdAttribute = "sample_tableid",
+            Attributes = new List<AttributeSchema>
+            {
+                new AttributeSchema
+                {
+                    LogicalName = "sample_primaryidattribute",
+                    DisplayName = "Primary Id Attribute",
+                    AttributeType = "String"
+                }
+            }
+        };
+
+        // Act
+        var result = generator.GenerateEntityClass(entity, "MyCompany.Constants");
+
+        // Assert
+        Assert.Contains("public const string PrimaryIdAttribute = \"sample_tableid\";", result);
+        Assert.DoesNotContain("public const string PrimaryIdAttribute = \"sample_primaryidattribute\";", result);
+        Assert.Contains("public const string PrimaryIdAttribute_ = \"sample_primaryidattribute\";", result);
+    }
+
+    [Fact]
+    public void GenerateEntityClass_ColumnNamedPrimaryNameAttribute_DeduplicatesAgainstHardCodedConstant()
+    {
+        // Arrange — column whose display name formats to PrimaryNameAttribute would duplicate the hard-coded constant
+        var formatter = new IdentifierFormatter();
+        var generator = new CodeTemplateGenerator(includeComments: false, includeRelationships: false, formatter);
+        var entity = new EntitySchema
+        {
+            LogicalName = "sample_table",
+            DisplayName = "Sample Table",
+            PrimaryNameAttribute = "sample_name",
+            Attributes = new List<AttributeSchema>
+            {
+                new AttributeSchema
+                {
+                    LogicalName = "sample_primarynameattribute",
+                    DisplayName = "Primary Name Attribute",
+                    AttributeType = "String"
+                }
+            }
+        };
+
+        // Act
+        var result = generator.GenerateEntityClass(entity, "MyCompany.Constants");
+
+        // Assert
+        Assert.Contains("public const string PrimaryNameAttribute = \"sample_name\";", result);
+        Assert.DoesNotContain("public const string PrimaryNameAttribute = \"sample_primarynameattribute\";", result);
+        Assert.Contains("public const string PrimaryNameAttribute_ = \"sample_primarynameattribute\";", result);
+    }
 }


### PR DESCRIPTION
## Summary

- Columns whose display names format to `EntityLogicalName`, `PrimaryIdAttribute`, or `PrimaryNameAttribute` would previously emit a duplicate `const string` in the generated class, causing a compile error in the output.
- Fix pre-seeds those three names into `usedAttributeNames` so the existing `MakeUnique` logic deduplicates them (e.g. `EntityLogicalName_`).
- `EntityLogicalName` is always reserved; `PrimaryIdAttribute` and `PrimaryNameAttribute` are reserved only when those entity properties are non-empty, matching exactly which hard-coded constants are actually emitted.

## Test plan

- [ ] `GenerateEntityClass_ColumnNamedEntityLogicalName_DeduplicatesAgainstHardCodedConstant` — new regression test
- [ ] `GenerateEntityClass_ColumnNamedPrimaryIdAttribute_DeduplicatesAgainstHardCodedConstant` — new regression test
- [ ] `GenerateEntityClass_ColumnNamedPrimaryNameAttribute_DeduplicatesAgainstHardCodedConstant` — new regression test
- [ ] Full test suite passes (359/359)

🤖 Generated with [Claude Code](https://claude.com/claude-code)