### PR TITLE
test: add unit tests for four reporter classes (78 tests)

### DIFF
--- a/tests/PowerApps.CLI.Tests/Services/ComparisonReporterTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/ComparisonReporterTests.cs
@@ -349,5 +349,717 @@ public class ComparisonReporterTests : IDisposable
         };
     }
 
+    private static ComparisonResult CreateResultWithTableDifference() =>
+        new()
+        {
+            TableResults =
+            {
+                new TableComparisonResult
+                {
+                    TableName = "account",
+                    SourceRecordCount = 5,
+                    TargetRecordCount = 4,
+                    Differences =
+                    {
+                        new RecordDifference { RecordId = Guid.NewGuid(), RecordName = "Test", DifferenceType = DifferenceType.New }
+                    }
+                }
+            }
+        };
+
+    private static RelationshipComparisonResult CreateRelationshipResult(string name, bool hasDifferences)
+    {
+        var rel = new RelationshipComparisonResult
+        {
+            RelationshipName = name,
+            IntersectEntity = "intersectentity",
+            SourceAssociationCount = 3,
+            TargetAssociationCount = 2
+        };
+        if (hasDifferences)
+        {
+            rel.Differences.Add(new AssociationDifference
+            {
+                Entity1Id = Guid.NewGuid(),
+                Entity1Name = "Entity 1",
+                Entity2Id = Guid.NewGuid(),
+                Entity2Name = "Entity 2",
+                DifferenceType = DifferenceType.New
+            });
+        }
+        return rel;
+    }
+
+    #endregion
+
+    #region No Differences Message Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_NoDifferences_ShowsCleanMessage()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "clean-message.xlsx");
+
+        await _reporter.GenerateReportAsync(new ComparisonResult(), outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        Assert.Equal(
+            "No differences found - all tables and relationships are in sync.",
+            ws.Cell(7, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_NoDifferences_CleanMessageIsGreen()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "clean-colour.xlsx");
+
+        await _reporter.GenerateReportAsync(new ComparisonResult(), outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        Assert.Equal(XLColor.Green, ws.Cell(7, 1).Style.Font.FontColor);
+    }
+
+    #endregion
+
+    #region Summary Sheet - Table Section Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WithTableDifferences_WritesSummaryTableCounts()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "table-counts.xlsx");
+        var result = new ComparisonResult
+        {
+            TableResults =
+            {
+                new TableComparisonResult
+                {
+                    TableName = "account",
+                    SourceRecordCount = 10,
+                    TargetRecordCount = 9,
+                    Differences =
+                    {
+                        new RecordDifference { RecordId = Guid.NewGuid(), DifferenceType = DifferenceType.New },
+                        new RecordDifference { RecordId = Guid.NewGuid(), DifferenceType = DifferenceType.Deleted },
+                        new RecordDifference
+                        {
+                            RecordId = Guid.NewGuid(),
+                            DifferenceType = DifferenceType.Modified,
+                            FieldDifferences = { new FieldDifference { FieldName = "name", SourceValue = "A", TargetValue = "B" } }
+                        }
+                    }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        // Row 7: "Table Comparisons", row 8: headers, row 9: first table data
+        Assert.Equal("account", ws.Cell(9, 1).Value.ToString());
+        Assert.Equal("10",      ws.Cell(9, 2).Value.ToString());
+        Assert.Equal("9",       ws.Cell(9, 3).Value.ToString());
+        Assert.Equal("1",       ws.Cell(9, 4).Value.ToString()); // NewCount
+        Assert.Equal("1",       ws.Cell(9, 5).Value.ToString()); // ModifiedCount
+        Assert.Equal("1",       ws.Cell(9, 6).Value.ToString()); // DeletedCount
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_TableWithDifferences_StatusCellIsRed()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "table-status-red.xlsx");
+
+        await _reporter.GenerateReportAsync(CreateResultWithTableDifference(), outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        Assert.Equal("Differences Found", ws.Cell(9, 7).Value.ToString());
+        Assert.Equal(XLColor.Red, ws.Cell(9, 7).Style.Font.FontColor);
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_TableInSync_StatusCellIsGreen()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "table-status-green.xlsx");
+        var result = new ComparisonResult
+        {
+            TableResults =
+            {
+                // Sorted alphabetically: account (in sync) comes before contact (differences)
+                new TableComparisonResult { TableName = "account", SourceRecordCount = 5, TargetRecordCount = 5 },
+                new TableComparisonResult
+                {
+                    TableName = "contact",
+                    Differences = { new RecordDifference { RecordId = Guid.NewGuid(), DifferenceType = DifferenceType.New } }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        Assert.Equal("In Sync", ws.Cell(9, 7).Value.ToString());
+        Assert.Equal(XLColor.Green, ws.Cell(9, 7).Style.Font.FontColor);
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_MultipleTablesInSummary_SortedAlphabetically()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "table-sort.xlsx");
+        var result = new ComparisonResult
+        {
+            TableResults =
+            {
+                new TableComparisonResult
+                {
+                    TableName = "Zebra",
+                    Differences = { new RecordDifference { RecordId = Guid.NewGuid(), DifferenceType = DifferenceType.New } }
+                },
+                new TableComparisonResult
+                {
+                    TableName = "Alpha",
+                    Differences = { new RecordDifference { RecordId = Guid.NewGuid(), DifferenceType = DifferenceType.New } }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        Assert.Equal("Alpha", ws.Cell(9,  1).Value.ToString());
+        Assert.Equal("Zebra", ws.Cell(10, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_TableWithDifferences_NameCellIsHyperlinked()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "table-hyperlink.xlsx");
+
+        await _reporter.GenerateReportAsync(CreateResultWithTableDifference(), outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        var nameCell = ws.Cell(9, 1);
+        Assert.Equal(XLColor.Blue, nameCell.Style.Font.FontColor);
+        Assert.Equal(XLFontUnderlineValues.Single, nameCell.Style.Font.Underline);
+    }
+
+    #endregion
+
+    #region Summary Sheet - Relationship Section Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WithRelationshipResults_CreatesRelationshipSection()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "rel-section.xlsx");
+        var result = new ComparisonResult
+        {
+            RelationshipResults = { CreateRelationshipResult("account_contact", hasDifferences: true) }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        // No table results → row 7 → row++ = 8 for "Relationship Comparisons"
+        Assert.Equal("Relationship Comparisons", ws.Cell(8, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WithRelationshipResults_WritesRelationshipCounts()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "rel-counts.xlsx");
+        var result = new ComparisonResult
+        {
+            RelationshipResults =
+            {
+                new RelationshipComparisonResult
+                {
+                    RelationshipName = "account_contact",
+                    SourceAssociationCount = 5,
+                    TargetAssociationCount = 3,
+                    Differences =
+                    {
+                        new AssociationDifference { Entity1Id = Guid.NewGuid(), Entity2Id = Guid.NewGuid(), DifferenceType = DifferenceType.New },
+                        new AssociationDifference { Entity1Id = Guid.NewGuid(), Entity2Id = Guid.NewGuid(), DifferenceType = DifferenceType.Deleted }
+                    }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        // Row 8: heading, row 9: headers, row 10: first rel data
+        Assert.Equal("account_contact", ws.Cell(10, 1).Value.ToString());
+        Assert.Equal("5",               ws.Cell(10, 2).Value.ToString()); // SourceAssociationCount
+        Assert.Equal("3",               ws.Cell(10, 3).Value.ToString()); // TargetAssociationCount
+        Assert.Equal("1",               ws.Cell(10, 4).Value.ToString()); // NewCount
+        Assert.Equal("1",               ws.Cell(10, 5).Value.ToString()); // DeletedCount
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_RelationshipWithDifferences_StatusIsRed()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "rel-status-red.xlsx");
+        var result = new ComparisonResult
+        {
+            RelationshipResults = { CreateRelationshipResult("account_contact", hasDifferences: true) }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        Assert.Equal("Differences Found", ws.Cell(10, 6).Value.ToString());
+        Assert.Equal(XLColor.Red, ws.Cell(10, 6).Style.Font.FontColor);
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_RelationshipInSync_StatusIsGreen()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "rel-status-green.xlsx");
+        var result = new ComparisonResult
+        {
+            // Two relationships sorted alphabetically: aaa_bbb (in sync), zzz_yyy (differences)
+            RelationshipResults =
+            {
+                new RelationshipComparisonResult { RelationshipName = "aaa_bbb" },
+                CreateRelationshipResult("zzz_yyy", hasDifferences: true)
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        // aaa_bbb at row 10 (in sync), zzz_yyy at row 11 (differences)
+        Assert.Equal("In Sync", ws.Cell(10, 6).Value.ToString());
+        Assert.Equal(XLColor.Green, ws.Cell(10, 6).Style.Font.FontColor);
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WithBothTablesAndRelationships_CreatesBothSections()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "both-sections.xlsx");
+        var result = new ComparisonResult
+        {
+            TableResults =
+            {
+                new TableComparisonResult
+                {
+                    TableName = "account",
+                    Differences = { new RecordDifference { RecordId = Guid.NewGuid(), DifferenceType = DifferenceType.New } }
+                }
+            },
+            RelationshipResults = { CreateRelationshipResult("account_contact", hasDifferences: true) }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        // Table section at row 7; relationship section at row 11 (1 table row + blank)
+        Assert.Equal("Table Comparisons",        ws.Cell(7,  1).Value.ToString());
+        Assert.Equal("Relationship Comparisons", ws.Cell(11, 1).Value.ToString());
+    }
+
+    #endregion
+
+    #region Table Detail Sheet Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_DetailSheet_HasCorrectTitle()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "detail-title.xlsx");
+
+        await _reporter.GenerateReportAsync(CreateComparisonResultWithDifference(DifferenceType.New), outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        Assert.Equal("Test Table - Differences", workbook.Worksheet("Test Table").Cell(1, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_DetailSheet_HasSummaryCounts()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "detail-counts.xlsx");
+        var result = new ComparisonResult
+        {
+            TableResults =
+            {
+                new TableComparisonResult
+                {
+                    TableName = "account",
+                    SourceRecordCount = 10,
+                    TargetRecordCount = 8,
+                    Differences =
+                    {
+                        new RecordDifference { RecordId = Guid.NewGuid(), DifferenceType = DifferenceType.New },
+                        new RecordDifference { RecordId = Guid.NewGuid(), DifferenceType = DifferenceType.Deleted }
+                    }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("account");
+        Assert.Equal("Total Source: 10",             ws.Cell(3, 1).Value.ToString());
+        Assert.Equal("Total Target: 8",              ws.Cell(4, 1).Value.ToString());
+        Assert.Equal("New: 1, Modified: 0, Deleted: 1", ws.Cell(5, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_ModifiedRecord_WritesFieldColumns()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "modified-fields.xlsx");
+        var recordId = Guid.NewGuid();
+        var result = new ComparisonResult
+        {
+            TableResults =
+            {
+                new TableComparisonResult
+                {
+                    TableName = "account",
+                    Differences =
+                    {
+                        new RecordDifference
+                        {
+                            RecordId = recordId,
+                            RecordName = "Test Account",
+                            DifferenceType = DifferenceType.Modified,
+                            FieldDifferences =
+                            {
+                                new FieldDifference { FieldName = "name", SourceValue = "Old Name", TargetValue = "New Name" }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("account");
+        Assert.Equal(recordId.ToString(), ws.Cell(8, 1).Value.ToString());
+        Assert.Equal("Test Account",      ws.Cell(8, 2).Value.ToString());
+        Assert.Equal("Modified",          ws.Cell(8, 3).Value.ToString());
+        Assert.Equal("name",              ws.Cell(8, 4).Value.ToString());
+        Assert.Equal("Old Name",          ws.Cell(8, 5).Value.ToString());
+        Assert.Equal("New Name",          ws.Cell(8, 6).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_NullFieldValues_WrittenAsNullText()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "null-values.xlsx");
+        var result = new ComparisonResult
+        {
+            TableResults =
+            {
+                new TableComparisonResult
+                {
+                    TableName = "account",
+                    Differences =
+                    {
+                        new RecordDifference
+                        {
+                            RecordId = Guid.NewGuid(),
+                            DifferenceType = DifferenceType.Modified,
+                            FieldDifferences =
+                            {
+                                new FieldDifference { FieldName = "description", SourceValue = null, TargetValue = null }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("account");
+        Assert.Equal("(null)", ws.Cell(8, 5).Value.ToString());
+        Assert.Equal("(null)", ws.Cell(8, 6).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_ModifiedRecordWithMultipleFields_OneRowPerField()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "multi-field.xlsx");
+        var result = new ComparisonResult
+        {
+            TableResults =
+            {
+                new TableComparisonResult
+                {
+                    TableName = "account",
+                    Differences =
+                    {
+                        new RecordDifference
+                        {
+                            RecordId = Guid.NewGuid(),
+                            DifferenceType = DifferenceType.Modified,
+                            FieldDifferences =
+                            {
+                                new FieldDifference { FieldName = "city", SourceValue = "London", TargetValue = "Paris" },
+                                new FieldDifference { FieldName = "name", SourceValue = "Old",    TargetValue = "New"   }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("account");
+        // Field diffs sorted by FieldName: city first, then name
+        Assert.Equal("city", ws.Cell(8, 4).Value.ToString());
+        Assert.Equal("name", ws.Cell(9, 4).Value.ToString());
+    }
+
+    #endregion
+
+    #region Relationship Detail Sheet Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_RelationshipWithDifferences_CreatesDetailSheet()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "rel-detail-sheet.xlsx");
+        var result = new ComparisonResult
+        {
+            RelationshipResults = { CreateRelationshipResult("account_contact", hasDifferences: true) }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        Assert.True(workbook.Worksheets.Contains("account_contact"));
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_RelationshipWithNoDifferences_NoDetailSheet()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "rel-no-detail.xlsx");
+        var result = new ComparisonResult
+        {
+            TableResults =
+            {
+                new TableComparisonResult
+                {
+                    TableName = "account",
+                    Differences = { new RecordDifference { RecordId = Guid.NewGuid(), DifferenceType = DifferenceType.New } }
+                }
+            },
+            RelationshipResults =
+            {
+                new RelationshipComparisonResult { RelationshipName = "account_contact" } // no differences
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        Assert.False(workbook.Worksheets.Contains("account_contact"));
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_RelationshipDetailSheet_HasCorrectTitle()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "rel-title.xlsx");
+        var result = new ComparisonResult
+        {
+            RelationshipResults = { CreateRelationshipResult("account_contact", hasDifferences: true) }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        Assert.Equal(
+            "account_contact - Differences",
+            workbook.Worksheet("account_contact").Cell(1, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_RelationshipDetailSheet_HasMetadata()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "rel-metadata.xlsx");
+        var result = new ComparisonResult
+        {
+            RelationshipResults =
+            {
+                new RelationshipComparisonResult
+                {
+                    RelationshipName = "account_contact",
+                    IntersectEntity = "accountcontact",
+                    SourceAssociationCount = 8,
+                    TargetAssociationCount = 6,
+                    Differences =
+                    {
+                        new AssociationDifference { Entity1Id = Guid.NewGuid(), Entity2Id = Guid.NewGuid(), DifferenceType = DifferenceType.New },
+                        new AssociationDifference { Entity1Id = Guid.NewGuid(), Entity2Id = Guid.NewGuid(), DifferenceType = DifferenceType.Deleted }
+                    }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("account_contact");
+        Assert.Equal("Intersect Entity: accountcontact", ws.Cell(3, 1).Value.ToString());
+        Assert.Equal("Total Source: 8",                  ws.Cell(4, 1).Value.ToString());
+        Assert.Equal("Total Target: 6",                  ws.Cell(5, 1).Value.ToString());
+        Assert.Equal("New: 1, Deleted: 1",               ws.Cell(6, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_RelationshipDetailSheet_WritesRowData()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "rel-row-data.xlsx");
+        var entity1Id = Guid.NewGuid();
+        var entity2Id = Guid.NewGuid();
+        var result = new ComparisonResult
+        {
+            RelationshipResults =
+            {
+                new RelationshipComparisonResult
+                {
+                    RelationshipName = "account_contact",
+                    Differences =
+                    {
+                        new AssociationDifference
+                        {
+                            Entity1Id   = entity1Id,
+                            Entity1Name = "Contoso Ltd",
+                            Entity2Id   = entity2Id,
+                            Entity2Name = "John Smith",
+                            DifferenceType = DifferenceType.New
+                        }
+                    }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("account_contact");
+        // Row 8: headers, row 9: first data row
+        Assert.Equal("Contoso Ltd",        ws.Cell(9, 1).Value.ToString());
+        Assert.Equal(entity1Id.ToString(), ws.Cell(9, 2).Value.ToString());
+        Assert.Equal("John Smith",         ws.Cell(9, 3).Value.ToString());
+        Assert.Equal(entity2Id.ToString(), ws.Cell(9, 4).Value.ToString());
+        Assert.Equal("New",                ws.Cell(9, 5).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_RelationshipDetailSheet_NullEntityNames_FallBackToId()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "rel-null-names.xlsx");
+        var entity1Id = Guid.NewGuid();
+        var entity2Id = Guid.NewGuid();
+        var result = new ComparisonResult
+        {
+            RelationshipResults =
+            {
+                new RelationshipComparisonResult
+                {
+                    RelationshipName = "account_contact",
+                    Differences =
+                    {
+                        new AssociationDifference
+                        {
+                            Entity1Id   = entity1Id,
+                            Entity1Name = null,
+                            Entity2Id   = entity2Id,
+                            Entity2Name = null,
+                            DifferenceType = DifferenceType.New
+                        }
+                    }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("account_contact");
+        Assert.Equal(entity1Id.ToString(), ws.Cell(9, 1).Value.ToString());
+        Assert.Equal(entity2Id.ToString(), ws.Cell(9, 3).Value.ToString());
+    }
+
+    #endregion
+
+    #region SanitizeSheetName Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_TableNameOver31Chars_SheetNameTruncated()
+    {
+        var longName = "A_Very_Long_Table_Name_That_Exceeds_Excel_Sheet_Limit";
+        var outputPath = Path.Combine(_tempDirectory, "long-name.xlsx");
+        var result = new ComparisonResult
+        {
+            TableResults =
+            {
+                new TableComparisonResult
+                {
+                    TableName = longName,
+                    Differences = { new RecordDifference { RecordId = Guid.NewGuid(), DifferenceType = DifferenceType.New } }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        Assert.True(workbook.Worksheets.Contains(longName.Substring(0, 31)));
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_TableNameWithSpecialChars_SheetNameSanitized()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "special-chars.xlsx");
+        var result = new ComparisonResult
+        {
+            TableResults =
+            {
+                new TableComparisonResult
+                {
+                    TableName = "Table[With]Special/Chars",
+                    Differences = { new RecordDifference { RecordId = Guid.NewGuid(), DifferenceType = DifferenceType.New } }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        Assert.True(workbook.Worksheets.Contains("Table_With_Special_Chars"));
+    }
+
+    #endregion
+
+    #region File Writer Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_CallsFileWriterWithCorrectPath()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "path-check.xlsx");
+
+        await _reporter.GenerateReportAsync(new ComparisonResult(), outputPath);
+
+        _mockFileWriter.Verify(x => x.WriteBytesAsync(outputPath, It.IsAny<byte[]>()), Times.Once);
+    }
+
     #endregion
 }

--- a/tests/PowerApps.CLI.Tests/Services/DataPatchReporterTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/DataPatchReporterTests.cs
@@ -1,0 +1,306 @@
+using ClosedXML.Excel;
+using Moq;
+using PowerApps.CLI.Infrastructure;
+using PowerApps.CLI.Models;
+using PowerApps.CLI.Services;
+using Xunit;
+
+namespace PowerApps.CLI.Tests.Services;
+
+public class DataPatchReporterTests : IDisposable
+{
+    private readonly Mock<IFileWriter> _mockFileWriter;
+    private readonly DataPatchReporter _reporter;
+    private readonly string _tempDirectory;
+
+    public DataPatchReporterTests()
+    {
+        _mockFileWriter = new Mock<IFileWriter>();
+        _reporter = new DataPatchReporter(_mockFileWriter.Object);
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"PowerAppsCLI_DataPatch_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDirectory);
+
+        _mockFileWriter
+            .Setup(x => x.WriteBytesAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
+            .Returns((string path, byte[] content) => File.WriteAllBytesAsync(path, content));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+            Directory.Delete(_tempDirectory, true);
+    }
+
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_WithNullFileWriter_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DataPatchReporter(null!));
+    }
+
+    #endregion
+
+    #region File Output Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesFileToDisk()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+
+        await _reporter.GenerateReportAsync(new DataPatchSummary(), outputPath);
+
+        Assert.True(File.Exists(outputPath));
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_CallsFileWriterWithCorrectPath()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+
+        await _reporter.GenerateReportAsync(new DataPatchSummary(), outputPath);
+
+        _mockFileWriter.Verify(x => x.WriteBytesAsync(outputPath, It.IsAny<byte[]>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Metadata Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesEnvironmentUrl()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new DataPatchSummary { EnvironmentUrl = "https://test.crm.dynamics.com" };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("https://test.crm.dynamics.com", ws.Cell(3, 2).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesFormattedExecutionDate()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new DataPatchSummary
+        {
+            ExecutionDate = new DateTime(2026, 6, 13, 10, 30, 0, DateTimeKind.Utc)
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("2026-06-13 10:30:00 UTC", ws.Cell(4, 2).Value.ToString());
+    }
+
+    #endregion
+
+    #region Summary Counts Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesSummaryCounts()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new DataPatchSummary
+        {
+            Results =
+            {
+                new PatchResult { Status = PatchStatus.Updated },
+                new PatchResult { Status = PatchStatus.Unchanged },
+                new PatchResult { Status = PatchStatus.NotFound }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("Updated:   1", ws.Cell(7, 1).Value.ToString());
+        Assert.Equal("Unchanged: 1", ws.Cell(8, 1).Value.ToString());
+        Assert.Equal("Failed:    1", ws.Cell(9, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_HasFailures_FailedSummaryCellIsRed()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report-failures.xlsx");
+        var summary = new DataPatchSummary
+        {
+            Results = { new PatchResult { Status = PatchStatus.NotFound } }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal(XLColor.Red, ws.Cell(9, 1).Style.Font.FontColor);
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_NoFailures_FailedSummaryCellIsNotRed()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report-no-failures.xlsx");
+        var summary = new DataPatchSummary
+        {
+            Results = { new PatchResult { Status = PatchStatus.Updated } }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.NotEqual(XLColor.Red, ws.Cell(9, 1).Style.Font.FontColor);
+    }
+
+    #endregion
+
+    #region Result Row Data Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WithResult_WritesRowData()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new DataPatchSummary
+        {
+            Results =
+            {
+                new PatchResult
+                {
+                    Entity = "account",
+                    Key = "ACC001",
+                    Field = "name",
+                    OldValue = "Old Name",
+                    NewValue = "New Name",
+                    Status = PatchStatus.Updated
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("account", ws.Cell(12, 1).Value.ToString());
+        Assert.Equal("ACC001", ws.Cell(12, 2).Value.ToString());
+        Assert.Equal("name", ws.Cell(12, 3).Value.ToString());
+        Assert.Equal("Old Name", ws.Cell(12, 4).Value.ToString());
+        Assert.Equal("New Name", ws.Cell(12, 5).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_NullOldAndNewValues_WriteEmptyStrings()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new DataPatchSummary
+        {
+            Results = { new PatchResult { OldValue = null, NewValue = null, Status = PatchStatus.Updated } }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal(string.Empty, ws.Cell(12, 4).Value.ToString());
+        Assert.Equal(string.Empty, ws.Cell(12, 5).Value.ToString());
+    }
+
+    #endregion
+
+    #region Status Text Tests
+
+    [Theory]
+    [InlineData(PatchStatus.Updated, "Updated")]
+    [InlineData(PatchStatus.Unchanged, "Unchanged")]
+    [InlineData(PatchStatus.NotFound, "Not Found")]
+    [InlineData(PatchStatus.AmbiguousMatch, "Ambiguous Match")]
+    public async Task GenerateReportAsync_StatusText_IsCorrect(PatchStatus status, string expectedText)
+    {
+        var outputPath = Path.Combine(_tempDirectory, $"report-{status}.xlsx");
+        var summary = new DataPatchSummary
+        {
+            Results = { new PatchResult { Status = status } }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal(expectedText, ws.Cell(12, 6).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_ErrorStatus_IncludesErrorMessage()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report-error.xlsx");
+        var summary = new DataPatchSummary
+        {
+            Results = { new PatchResult { Status = PatchStatus.Error, ErrorMessage = "Record locked" } }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("Error: Record locked", ws.Cell(12, 6).Value.ToString());
+    }
+
+    #endregion
+
+    #region Status Colour Tests
+
+    [Theory]
+    [InlineData(PatchStatus.NotFound)]
+    [InlineData(PatchStatus.AmbiguousMatch)]
+    [InlineData(PatchStatus.Error)]
+    public async Task GenerateReportAsync_FailureStatus_StatusCellIsRed(PatchStatus status)
+    {
+        var outputPath = Path.Combine(_tempDirectory, $"report-color-{status}.xlsx");
+        var summary = new DataPatchSummary
+        {
+            Results = { new PatchResult { Status = status } }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal(XLColor.Red, ws.Cell(12, 6).Style.Font.FontColor);
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_UpdatedStatus_StatusCellIsDarkGreen()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report-updated.xlsx");
+        var summary = new DataPatchSummary
+        {
+            Results = { new PatchResult { Status = PatchStatus.Updated } }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal(XLColor.DarkGreen, ws.Cell(12, 6).Style.Font.FontColor);
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_UnchangedStatus_StatusCellIsGray()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report-unchanged.xlsx");
+        var summary = new DataPatchSummary
+        {
+            Results = { new PatchResult { Status = PatchStatus.Unchanged } }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal(XLColor.Gray, ws.Cell(12, 6).Style.Font.FontColor);
+    }
+
+    #endregion
+}

--- a/tests/PowerApps.CLI.Tests/Services/MigrationReporterTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/MigrationReporterTests.cs
@@ -1,0 +1,392 @@
+using ClosedXML.Excel;
+using Moq;
+using PowerApps.CLI.Infrastructure;
+using PowerApps.CLI.Models;
+using PowerApps.CLI.Services;
+using Xunit;
+
+namespace PowerApps.CLI.Tests.Services;
+
+public class MigrationReporterTests : IDisposable
+{
+    private readonly Mock<IFileWriter> _mockFileWriter;
+    private readonly MigrationReporter _reporter;
+    private readonly string _tempDirectory;
+
+    public MigrationReporterTests()
+    {
+        _mockFileWriter = new Mock<IFileWriter>();
+        _reporter = new MigrationReporter(_mockFileWriter.Object);
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"PowerAppsCLI_Migration_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDirectory);
+
+        _mockFileWriter
+            .Setup(x => x.WriteBytesAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
+            .Returns((string path, byte[] content) => File.WriteAllBytesAsync(path, content));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+            Directory.Delete(_tempDirectory, true);
+    }
+
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_WithNullFileWriter_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new MigrationReporter(null!));
+    }
+
+    #endregion
+
+    #region File Output Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesFileToDisk()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+
+        await _reporter.GenerateReportAsync(new MigrationSummary(), outputPath);
+
+        Assert.True(File.Exists(outputPath));
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_CallsFileWriterWithCorrectPath()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+
+        await _reporter.GenerateReportAsync(new MigrationSummary(), outputPath);
+
+        _mockFileWriter.Verify(x => x.WriteBytesAsync(outputPath, It.IsAny<byte[]>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Sheet Structure Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_NoErrors_OnlyCreatesSummarySheet()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new MigrationSummary(); // HasErrors = false
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        Assert.Single(workbook.Worksheets);
+        Assert.True(workbook.Worksheets.Contains("Migration Summary"));
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WithErrors_CreatesErrorsSheet()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new MigrationSummary
+        {
+            TableResults =
+            {
+                new TableMigrationResult
+                {
+                    TableName = "account",
+                    Errors = { new RecordError { TableName = "account", RecordId = Guid.NewGuid(), Phase = "Upsert", ErrorMessage = "Failed" } }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        Assert.Equal(2, workbook.Worksheets.Count);
+        Assert.True(workbook.Worksheets.Contains("Migration Summary"));
+        Assert.True(workbook.Worksheets.Contains("Errors"));
+    }
+
+    #endregion
+
+    #region Metadata Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesSourceAndTargetEnvironments()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new MigrationSummary
+        {
+            SourceEnvironment = "https://source.crm.dynamics.com",
+            TargetEnvironment = "https://target.crm.dynamics.com"
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Migration Summary");
+        Assert.Equal("https://source.crm.dynamics.com", ws.Cell(3, 2).Value.ToString());
+        Assert.Equal("https://target.crm.dynamics.com", ws.Cell(4, 2).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesFormattedExecutionDate()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new MigrationSummary
+        {
+            ExecutionDate = new DateTime(2026, 6, 13, 14, 0, 0, DateTimeKind.Utc)
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Migration Summary");
+        Assert.Equal("2026-06-13 14:00:00 UTC", ws.Cell(5, 2).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_IsDryRun_WritesDryRunMode()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new MigrationSummary { IsDryRun = true };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Migration Summary");
+        Assert.Equal("Dry Run (Preview)", ws.Cell(6, 2).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_IsNotDryRun_WritesExecutedMode()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new MigrationSummary { IsDryRun = false };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Migration Summary");
+        Assert.Equal("Executed", ws.Cell(6, 2).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesFormattedDuration()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new MigrationSummary { Duration = new TimeSpan(0, 0, 2, 35, 750) };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Migration Summary");
+        Assert.Equal("02:35.750", ws.Cell(7, 2).Value.ToString());
+    }
+
+    #endregion
+
+    #region Totals Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesTotalsAggregatedFromTableResults()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new MigrationSummary
+        {
+            TableResults =
+            {
+                new TableMigrationResult { RecordCount = 10, UpsertedCount = 8, LookupsPatchedCount = 3, StateChangesCount = 2, SkippedCount = 2 },
+                new TableMigrationResult { RecordCount = 5,  UpsertedCount = 5, LookupsPatchedCount = 1, StateChangesCount = 0, SkippedCount = 0 }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Migration Summary");
+        Assert.Equal("15", ws.Cell(10, 2).Value.ToString()); // TotalRecords
+        Assert.Equal("13", ws.Cell(11, 2).Value.ToString()); // TotalUpserted
+        Assert.Equal("4",  ws.Cell(12, 2).Value.ToString()); // TotalLookupsPatched
+        Assert.Equal("2",  ws.Cell(13, 2).Value.ToString()); // TotalStateChanges
+        Assert.Equal("2",  ws.Cell(14, 2).Value.ToString()); // TotalSkipped
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_HasErrors_ErrorsTotalCellIsRed()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new MigrationSummary
+        {
+            TableResults =
+            {
+                new TableMigrationResult
+                {
+                    Errors = { new RecordError { TableName = "account", RecordId = Guid.NewGuid(), Phase = "Upsert", ErrorMessage = "Fail" } }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Migration Summary");
+        Assert.Equal(XLColor.Red, ws.Cell(17, 2).Style.Font.FontColor);
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_NoErrors_ErrorsTotalCellIsNotRed()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+
+        await _reporter.GenerateReportAsync(new MigrationSummary(), outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Migration Summary");
+        Assert.NotEqual(XLColor.Red, ws.Cell(17, 2).Style.Font.FontColor);
+    }
+
+    #endregion
+
+    #region Table Results Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WithTableResults_WritesTableRowData()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new MigrationSummary
+        {
+            TableResults =
+            {
+                new TableMigrationResult
+                {
+                    TableName = "contact",
+                    RecordCount = 20,
+                    UpsertedCount = 18,
+                    LookupsPatchedCount = 5,
+                    StateChangesCount = 3,
+                    SkippedCount = 2
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Migration Summary");
+        Assert.Equal("contact", ws.Cell(20, 1).Value.ToString());
+        Assert.Equal("20", ws.Cell(20, 2).Value.ToString());
+        Assert.Equal("18", ws.Cell(20, 3).Value.ToString());
+        Assert.Equal("5",  ws.Cell(20, 4).Value.ToString());
+        Assert.Equal("3",  ws.Cell(20, 5).Value.ToString());
+        Assert.Equal("2",  ws.Cell(20, 6).Value.ToString());
+    }
+
+    #endregion
+
+    #region ManyToMany Results Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_NoManyToManyResults_NoManyToManySection()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new MigrationSummary
+        {
+            TableResults = { new TableMigrationResult { TableName = "account", RecordCount = 1 } }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Migration Summary");
+        // Row 21 onwards should be empty (no N:N header)
+        Assert.Equal(string.Empty, ws.Cell(23, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WithManyToManyResults_WritesManyToManyData()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new MigrationSummary
+        {
+            TableResults = { new TableMigrationResult { TableName = "account", RecordCount = 2 } },
+            ManyToManyResults =
+            {
+                new ManyToManyMigrationResult
+                {
+                    RelationshipName = "account_contact",
+                    Entity1Name = "account",
+                    Entity2Name = "contact",
+                    SourceCount = 5,
+                    AssociatedCount = 3,
+                    DisassociatedCount = 1
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Migration Summary");
+        // N:N section starts after table data + blank + "N:N Relationships" heading + header row
+        // Row 20: account data, row 21: blank, row 22: "N:N Relationships", row 23: header, row 24: data
+        Assert.Equal("account_contact", ws.Cell(24, 1).Value.ToString());
+        Assert.Equal("account", ws.Cell(24, 2).Value.ToString());
+        Assert.Equal("contact", ws.Cell(24, 3).Value.ToString());
+        Assert.Equal("5", ws.Cell(24, 4).Value.ToString());
+        Assert.Equal("3", ws.Cell(24, 5).Value.ToString());
+        Assert.Equal("1", ws.Cell(24, 6).Value.ToString());
+    }
+
+    #endregion
+
+    #region Errors Sheet Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_ErrorsSheet_ContainsTableAndManyToManyErrors()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var tableRecordId = Guid.NewGuid();
+        var m2mRecordId = Guid.NewGuid();
+        var summary = new MigrationSummary
+        {
+            TableResults =
+            {
+                new TableMigrationResult
+                {
+                    TableName = "account",
+                    Errors =
+                    {
+                        new RecordError { TableName = "account", RecordId = tableRecordId, Phase = "Upsert", ErrorMessage = "Table error" }
+                    }
+                }
+            },
+            ManyToManyResults =
+            {
+                new ManyToManyMigrationResult
+                {
+                    RelationshipName = "account_contact",
+                    Errors =
+                    {
+                        new RecordError { TableName = "account_contact", RecordId = m2mRecordId, Phase = "Associate", ErrorMessage = "M2M error" }
+                    }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var errorsSheet = workbook.Worksheet("Errors");
+        Assert.NotNull(errorsSheet);
+        // Row 1 is the header; data starts at row 2
+        Assert.Equal("account", errorsSheet.Cell(2, 1).Value.ToString());
+        Assert.Equal(tableRecordId.ToString(), errorsSheet.Cell(2, 2).Value.ToString());
+        Assert.Equal("Upsert", errorsSheet.Cell(2, 3).Value.ToString());
+        Assert.Equal("Table error", errorsSheet.Cell(2, 4).Value.ToString());
+
+        Assert.Equal("account_contact", errorsSheet.Cell(3, 1).Value.ToString());
+        Assert.Equal(m2mRecordId.ToString(), errorsSheet.Cell(3, 2).Value.ToString());
+        Assert.Equal("Associate", errorsSheet.Cell(3, 3).Value.ToString());
+        Assert.Equal("M2M error", errorsSheet.Cell(3, 4).Value.ToString());
+    }
+
+    #endregion
+}

--- a/tests/PowerApps.CLI.Tests/Services/ProcessReporterTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/ProcessReporterTests.cs
@@ -1,0 +1,372 @@
+using ClosedXML.Excel;
+using Moq;
+using PowerApps.CLI.Infrastructure;
+using PowerApps.CLI.Models;
+using PowerApps.CLI.Services;
+using Xunit;
+
+namespace PowerApps.CLI.Tests.Services;
+
+public class ProcessReporterTests : IDisposable
+{
+    private readonly Mock<IFileWriter> _mockFileWriter;
+    private readonly ProcessReporter _reporter;
+    private readonly string _tempDirectory;
+
+    public ProcessReporterTests()
+    {
+        _mockFileWriter = new Mock<IFileWriter>();
+        _reporter = new ProcessReporter(_mockFileWriter.Object);
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"PowerAppsCLI_ProcessReporter_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDirectory);
+
+        _mockFileWriter
+            .Setup(x => x.WriteBytesAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
+            .Returns((string path, byte[] content) => File.WriteAllBytesAsync(path, content));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+            Directory.Delete(_tempDirectory, true);
+    }
+
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_WithNullFileWriter_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ProcessReporter(null!));
+    }
+
+    #endregion
+
+    #region File Output Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesFileToDisk()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+
+        await _reporter.GenerateReportAsync(new ProcessManageSummary(), outputPath);
+
+        Assert.True(File.Exists(outputPath));
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_CallsFileWriterWithCorrectPath()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+
+        await _reporter.GenerateReportAsync(new ProcessManageSummary(), outputPath);
+
+        _mockFileWriter.Verify(x => x.WriteBytesAsync(outputPath, It.IsAny<byte[]>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Metadata Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesEnvironmentUrl()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new ProcessManageSummary { EnvironmentUrl = "https://test.crm.dynamics.com" };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("https://test.crm.dynamics.com", ws.Cell(3, 2).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesFormattedExecutionDate()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new ProcessManageSummary
+        {
+            ExecutionDate = new DateTime(2026, 6, 13, 9, 0, 0, DateTimeKind.Utc)
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("2026-06-13 09:00:00 UTC", ws.Cell(4, 2).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_IsDryRun_WritesDryRunMode()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new ProcessManageSummary { IsDryRun = true };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("Dry Run (Preview)", ws.Cell(5, 2).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_IsNotDryRun_WritesExecutedMode()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new ProcessManageSummary { IsDryRun = false };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("Executed", ws.Cell(5, 2).Value.ToString());
+    }
+
+    #endregion
+
+    #region Summary Counts Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesSummaryCounts()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new ProcessManageSummary
+        {
+            Results =
+            {
+                MakeResult("A", ProcessAction.Activated),
+                MakeResult("B", ProcessAction.Deactivated),
+                MakeResult("C", ProcessAction.NoChangeNeeded),
+                MakeResult("D", ProcessAction.Failed)
+            }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("Total Processes: 4", ws.Cell(8, 1).Value.ToString());
+        Assert.Equal("Activated: 1",       ws.Cell(9, 1).Value.ToString());
+        Assert.Equal("Deactivated: 1",     ws.Cell(10, 1).Value.ToString());
+        Assert.Equal("Unchanged: 1",       ws.Cell(11, 1).Value.ToString());
+        Assert.Equal("Failed: 1",          ws.Cell(12, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_HasFailures_FailedSummaryCellIsRed()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report-failures.xlsx");
+        var summary = new ProcessManageSummary
+        {
+            Results = { MakeResult("Flow1", ProcessAction.Failed) }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal(XLColor.Red, ws.Cell(12, 1).Style.Font.FontColor);
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_NoFailures_FailedSummaryCellIsNotRed()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report-no-failures.xlsx");
+        var summary = new ProcessManageSummary
+        {
+            Results = { MakeResult("Flow1", ProcessAction.Activated) }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.NotEqual(XLColor.Red, ws.Cell(12, 1).Style.Font.FontColor);
+    }
+
+    #endregion
+
+    #region Result Row Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WithResults_SortsByProcessName()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new ProcessManageSummary
+        {
+            Results =
+            {
+                MakeResult("Zebra Flow",  ProcessAction.Activated),
+                MakeResult("Alpha Flow",  ProcessAction.Activated),
+                MakeResult("Middle Flow", ProcessAction.Activated)
+            }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("Alpha Flow",  ws.Cell(15, 1).Value.ToString());
+        Assert.Equal("Middle Flow", ws.Cell(16, 1).Value.ToString());
+        Assert.Equal("Zebra Flow",  ws.Cell(17, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WithResult_WritesProcessStateColumns()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new ProcessManageSummary
+        {
+            Results =
+            {
+                new ProcessManageResult
+                {
+                    Process = new ProcessInfo
+                    {
+                        Name = "My Flow",
+                        Type = ProcessType.CloudFlow,
+                        ExpectedState = ProcessState.Active,
+                        CurrentState = ProcessState.Inactive
+                    },
+                    Action = ProcessAction.Activated
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("My Flow",   ws.Cell(15, 1).Value.ToString());
+        Assert.Equal("Cloud Flow", ws.Cell(15, 2).Value.ToString());
+        Assert.Equal("Active",    ws.Cell(15, 3).Value.ToString());
+        Assert.Equal("Inactive",  ws.Cell(15, 4).Value.ToString());
+        Assert.Equal("Activated", ws.Cell(15, 5).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WithErrorMessage_WritesErrorMessageColumn()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var summary = new ProcessManageSummary
+        {
+            Results =
+            {
+                new ProcessManageResult
+                {
+                    Process = new ProcessInfo { Name = "Bad Flow" },
+                    Action = ProcessAction.Failed,
+                    ErrorMessage = "Access denied"
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal("Access denied", ws.Cell(15, 6).Value.ToString());
+    }
+
+    #endregion
+
+    #region Process Type Name Tests
+
+    [Theory]
+    [InlineData(ProcessType.Workflow, "Workflow")]
+    [InlineData(ProcessType.BusinessRule, "Business Rule")]
+    [InlineData(ProcessType.Action, "Action")]
+    [InlineData(ProcessType.BusinessProcessFlow, "Business Process Flow")]
+    [InlineData(ProcessType.CloudFlow, "Cloud Flow")]
+    [InlineData(ProcessType.DuplicateDetectionRule, "Duplicate Detection Rule")]
+    public async Task GenerateReportAsync_ProcessTypeName_IsCorrect(ProcessType type, string expectedName)
+    {
+        var outputPath = Path.Combine(_tempDirectory, $"report-{type}.xlsx");
+        var summary = new ProcessManageSummary
+        {
+            Results = { new ProcessManageResult { Process = new ProcessInfo { Name = "P", Type = type }, Action = ProcessAction.NoChangeNeeded } }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal(expectedName, ws.Cell(15, 2).Value.ToString());
+    }
+
+    #endregion
+
+    #region Action Text Tests
+
+    [Theory]
+    [InlineData(ProcessAction.NoChangeNeeded, "Unchanged")]
+    [InlineData(ProcessAction.Activated, "Activated")]
+    [InlineData(ProcessAction.Deactivated, "Deactivated")]
+    [InlineData(ProcessAction.Failed, "Failed")]
+    public async Task GenerateReportAsync_ActionText_IsCorrect(ProcessAction action, string expectedText)
+    {
+        var outputPath = Path.Combine(_tempDirectory, $"report-{action}.xlsx");
+        var summary = new ProcessManageSummary
+        {
+            Results = { MakeResult("P", action) }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal(expectedText, ws.Cell(15, 5).Value.ToString());
+    }
+
+    #endregion
+
+    #region Action Colour Tests
+
+    [Theory]
+    [InlineData(ProcessAction.Activated)]
+    [InlineData(ProcessAction.Deactivated)]
+    public async Task GenerateReportAsync_ActivatedOrDeactivated_ActionCellIsBlue(ProcessAction action)
+    {
+        var outputPath = Path.Combine(_tempDirectory, $"report-{action}.xlsx");
+        var summary = new ProcessManageSummary
+        {
+            Results = { MakeResult("P", action) }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal(XLColor.Blue, ws.Cell(15, 5).Style.Font.FontColor);
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_FailedAction_ActionCellIsRed()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report-failed.xlsx");
+        var summary = new ProcessManageSummary
+        {
+            Results = { MakeResult("P", ProcessAction.Failed) }
+        };
+
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheets.First();
+        Assert.Equal(XLColor.Red, ws.Cell(15, 5).Style.Font.FontColor);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static ProcessManageResult MakeResult(string name, ProcessAction action) =>
+        new()
+        {
+            Process = new ProcessInfo { Name = name },
+            Action = action,
+            Success = action != ProcessAction.Failed
+        };
+
+    #endregion
+}

--- a/tests/PowerApps.CLI.Tests/Services/SolutionLayerReporterTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/SolutionLayerReporterTests.cs
@@ -1,0 +1,322 @@
+using ClosedXML.Excel;
+using Moq;
+using PowerApps.CLI.Infrastructure;
+using PowerApps.CLI.Models;
+using PowerApps.CLI.Services;
+using Xunit;
+
+namespace PowerApps.CLI.Tests.Services;
+
+public class SolutionLayerReporterTests : IDisposable
+{
+    private readonly Mock<IFileWriter> _mockFileWriter;
+    private readonly SolutionLayerReporter _reporter;
+    private readonly string _tempDirectory;
+
+    public SolutionLayerReporterTests()
+    {
+        _mockFileWriter = new Mock<IFileWriter>();
+        _reporter = new SolutionLayerReporter(_mockFileWriter.Object);
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"PowerAppsCLI_SolutionLayer_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDirectory);
+
+        _mockFileWriter
+            .Setup(x => x.WriteBytesAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
+            .Returns((string path, byte[] content) => File.WriteAllBytesAsync(path, content));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+            Directory.Delete(_tempDirectory, true);
+    }
+
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_WithNullFileWriter_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SolutionLayerReporter(null!));
+    }
+
+    #endregion
+
+    #region File Output Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesFileToDisk()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+
+        await _reporter.GenerateReportAsync(new SolutionLayerResult(), outputPath);
+
+        Assert.True(File.Exists(outputPath));
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_CallsFileWriterWithCorrectPath()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+
+        await _reporter.GenerateReportAsync(new SolutionLayerResult(), outputPath);
+
+        _mockFileWriter.Verify(x => x.WriteBytesAsync(outputPath, It.IsAny<byte[]>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Sheet Structure Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_NoUnmanagedLayers_OnlyCreatesSummarySheet()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var result = new SolutionLayerResult(); // HasUnmanagedLayers = false
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        Assert.Single(workbook.Worksheets);
+        Assert.True(workbook.Worksheets.Contains("Summary"));
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WithUnmanagedLayers_CreatesBothSheets()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var result = new SolutionLayerResult
+        {
+            LayeredComponents = { MakeComponent("field1") }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        Assert.Equal(2, workbook.Worksheets.Count);
+        Assert.True(workbook.Worksheets.Contains("Summary"));
+        Assert.True(workbook.Worksheets.Contains("Unmanaged Layers"));
+    }
+
+    #endregion
+
+    #region Summary Sheet Metadata Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesSolutionNameAndEnvironment()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var result = new SolutionLayerResult
+        {
+            SolutionName = "MySolution",
+            EnvironmentUrl = "https://test.crm.dynamics.com"
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        Assert.Equal("MySolution", ws.Cell(3, 2).Value.ToString());
+        Assert.Equal("https://test.crm.dynamics.com", ws.Cell(4, 2).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WritesFormattedReportDate()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var result = new SolutionLayerResult
+        {
+            ReportDate = new DateTime(2026, 6, 13, 12, 0, 0, DateTimeKind.Utc)
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        Assert.Equal("2026-06-13 12:00:00 UTC", ws.Cell(5, 2).Value.ToString());
+    }
+
+    #endregion
+
+    #region Clean State Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_NoUnmanagedLayers_ShowsCleanMessage()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+
+        await _reporter.GenerateReportAsync(new SolutionLayerResult(), outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        Assert.Equal(
+            "No unmanaged layers detected. All components are clean.",
+            ws.Cell(7, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_NoUnmanagedLayers_CleanMessageIsDarkGreen()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+
+        await _reporter.GenerateReportAsync(new SolutionLayerResult(), outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        Assert.Equal(XLColor.DarkGreen, ws.Cell(7, 1).Style.Font.FontColor);
+    }
+
+    #endregion
+
+    #region Unmanaged Layers — Summary Sheet Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_WithUnmanagedLayers_ShowsWarningWithCount()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var result = new SolutionLayerResult
+        {
+            LayeredComponents = { MakeComponent("field1"), MakeComponent("field2") }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        Assert.Equal("WARNING: 2 component(s) have unmanaged layers.", ws.Cell(7, 1).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WithUnmanagedLayers_WarningIsRed()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var result = new SolutionLayerResult
+        {
+            LayeredComponents = { MakeComponent("field1") }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        Assert.Equal(XLColor.Red, ws.Cell(7, 1).Style.Font.FontColor);
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_SummarySheet_WritesComponentData()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var result = new SolutionLayerResult
+        {
+            LayeredComponents =
+            {
+                new LayeredComponent
+                {
+                    ComponentType = "Attribute",
+                    ComponentName = "rob_name",
+                    ParentEntity = "account",
+                    AllLayers = new List<string> { "Active Solution", "Unmanaged" }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Summary");
+        // Row 7: warning, row 8: blank, row 9: header, row 10: data
+        Assert.Equal("Attribute",                   ws.Cell(10, 1).Value.ToString());
+        Assert.Equal("rob_name",                    ws.Cell(10, 2).Value.ToString());
+        Assert.Equal("account",                     ws.Cell(10, 3).Value.ToString());
+        Assert.Equal("Active Solution → Unmanaged", ws.Cell(10, 4).Value.ToString());
+    }
+
+    #endregion
+
+    #region Unmanaged Layers Sheet Tests
+
+    [Fact]
+    public async Task GenerateReportAsync_LayersSheet_WritesComponentDetail()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var result = new SolutionLayerResult
+        {
+            LayeredComponents =
+            {
+                new LayeredComponent
+                {
+                    ComponentType = "Attribute",
+                    ComponentName = "rob_status",
+                    ParentEntity = "contact",
+                    UnmanagedLayerOwner = "Rob",
+                    AllLayers = new List<string> { "Base", "Rob" }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Unmanaged Layers");
+        // Row 3 is header, data starts at row 4
+        Assert.Equal("Attribute",  ws.Cell(4, 1).Value.ToString());
+        Assert.Equal("rob_status", ws.Cell(4, 2).Value.ToString());
+        Assert.Equal("contact",    ws.Cell(4, 3).Value.ToString());
+        Assert.Equal("Rob",        ws.Cell(4, 4).Value.ToString());
+        Assert.Equal("Base → Rob", ws.Cell(4, 5).Value.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_LayersSheet_UnmanagedLayerOwnerCellIsRed()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var result = new SolutionLayerResult
+        {
+            LayeredComponents = { MakeComponent("rob_field") }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Unmanaged Layers");
+        Assert.Equal(XLColor.Red, ws.Cell(4, 4).Style.Font.FontColor);
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_LayersSheet_AllLayersJoinedWithArrow()
+    {
+        var outputPath = Path.Combine(_tempDirectory, "report.xlsx");
+        var result = new SolutionLayerResult
+        {
+            LayeredComponents =
+            {
+                new LayeredComponent
+                {
+                    ComponentName = "field1",
+                    AllLayers = new List<string> { "Layer A", "Layer B", "Layer C" }
+                }
+            }
+        };
+
+        await _reporter.GenerateReportAsync(result, outputPath);
+
+        using var workbook = new XLWorkbook(outputPath);
+        var ws = workbook.Worksheet("Unmanaged Layers");
+        Assert.Equal("Layer A → Layer B → Layer C", ws.Cell(4, 5).Value.ToString());
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static LayeredComponent MakeComponent(string name) =>
+        new()
+        {
+            ComponentName = name,
+            ComponentType = "Attribute",
+            ParentEntity = "account",
+            UnmanagedLayerOwner = "Rob",
+            AllLayers = new List<string> { "Managed", "Unmanaged" }
+        };
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- All four Excel reporter classes (`DataPatchReporter`, `MigrationReporter`, `ProcessReporter`, `SolutionLayerReporter`) were at 0% coverage — this PR brings them up with 78 new unit tests
- Follows the same pattern as `ComparisonReporterTests`: `IFileWriter` is mocked to write to a temp directory, the resulting `.xlsx` is loaded back via `XLWorkbook`, and assertions are made against cell values, sheet structure, and font colours
- Fixed a test bug during development: `new TimeSpan(0, 2, 35, 750)` uses the 4-param overload where the last arg is seconds, not milliseconds — corrected to `new TimeSpan(0, 0, 2, 35, 750)`

## Test plan

- [x] `DataPatchReporterTests` — 14 tests: constructor, file output, metadata, summary counts, row data, status text (theory), status colours
- [x] `MigrationReporterTests` — 16 tests: constructor, file output, sheet structure (errors sheet conditional), metadata, dry run mode, duration formatting, totals aggregation, table rows, N:N section, errors sheet content
- [x] `ProcessReporterTests` — 18 tests: constructor, file output, metadata, dry run mode, summary counts, sort order, row data, process type names (theory), action text (theory), action colours
- [x] `SolutionLayerReporterTests` — 16 tests: constructor, file output, sheet structure (layers sheet conditional), metadata, clean message colour, warning message and colour, summary component data, layers sheet detail, layer arrow separator, unmanaged owner colour
- [x] Full test suite passes (440/440)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)