### PR TITLE
feat: add plugin step support to process-manage

### DIFF
--- a/src/PowerApps.CLI/Infrastructure/DataverseClient.cs
+++ b/src/PowerApps.CLI/Infrastructure/DataverseClient.cs
@@ -63,6 +63,7 @@ public class DataverseClient : IDataverseClient
     private string _clientSecret {get;set;} = string.Empty;
     private string _connectionString {get;set;} = string.Empty;
     private readonly ServiceClient _serviceClient;
+    private readonly IOrganizationService _orgService;
 
     public DataverseClient(string url, string? clientId = null, string? clientSecret = null, string? connectionString = null)
     {
@@ -71,6 +72,14 @@ public class DataverseClient : IDataverseClient
         _clientSecret = clientSecret ?? string.Empty;
         _connectionString = connectionString ?? string.Empty;
         _serviceClient = Connect(_url, _clientId, _clientSecret, _connectionString);
+        _orgService = _serviceClient;
+    }
+
+    // For unit testing only — ServiceClient-specific members (GetOrganizationName, GetEnvironmentUrl) are unavailable.
+    internal DataverseClient(IOrganizationService orgService)
+    {
+        _serviceClient = null!;
+        _orgService = orgService;
     }
 
     public string GetOrganizationName()
@@ -354,6 +363,49 @@ public class DataverseClient : IDataverseClient
             Status = new OptionSetValue(0)  // Unpublished
         };
         _serviceClient.Execute(request);
+    }
+
+    public EntityCollection RetrievePluginSteps(List<string> solutions)
+    {
+        var query = new QueryExpression("sdkmessageprocessingstep")
+        {
+            ColumnSet = new ColumnSet("sdkmessageprocessingstepid", "name", "statecode"),
+            Criteria = new FilterExpression(LogicalOperator.And)
+        };
+
+        if (solutions.Any())
+        {
+            foreach (var solution in solutions)
+            {
+                var componentLink = query.AddLink("solutioncomponent", "sdkmessageprocessingstepid", "objectid");
+                var solutionLink = componentLink.AddLink("solution", "solutionid", "solutionid");
+                solutionLink.LinkCriteria.AddCondition("uniquename", ConditionOperator.Equal, solution);
+            }
+        }
+
+        return _orgService.RetrieveMultiple(query);
+    }
+
+    public void EnablePluginStep(Guid stepId)
+    {
+        var request = new SetStateRequest
+        {
+            EntityMoniker = new EntityReference("sdkmessageprocessingstep", stepId),
+            State = new OptionSetValue(0), // Enabled
+            Status = new OptionSetValue(1)  // Enabled
+        };
+        _orgService.Execute(request);
+    }
+
+    public void DisablePluginStep(Guid stepId)
+    {
+        var request = new SetStateRequest
+        {
+            EntityMoniker = new EntityReference("sdkmessageprocessingstep", stepId),
+            State = new OptionSetValue(1), // Disabled
+            Status = new OptionSetValue(2)  // Disabled
+        };
+        _orgService.Execute(request);
     }
 
     public EntityCollection RetrieveRecordsByFetchXml(string fetchXml)

--- a/src/PowerApps.CLI/Infrastructure/IDataverseClient.cs
+++ b/src/PowerApps.CLI/Infrastructure/IDataverseClient.cs
@@ -106,6 +106,25 @@ public interface IDataverseClient
     void DeactivateDuplicateRule(Guid ruleId);
 
     /// <summary>
+    /// Retrieves plugin step records, optionally filtered by solution names.
+    /// </summary>
+    /// <param name="solutions">Solution unique names to filter by. If empty, retrieves all steps.</param>
+    /// <returns>Collection of sdkmessageprocessingstep entities.</returns>
+    EntityCollection RetrievePluginSteps(List<string> solutions);
+
+    /// <summary>
+    /// Enables a plugin step (statecode=0, statuscode=1).
+    /// </summary>
+    /// <param name="stepId">The ID of the plugin step to enable.</param>
+    void EnablePluginStep(Guid stepId);
+
+    /// <summary>
+    /// Disables a plugin step (statecode=1, statuscode=2).
+    /// </summary>
+    /// <param name="stepId">The ID of the plugin step to disable.</param>
+    void DisablePluginStep(Guid stepId);
+
+    /// <summary>
     /// Retrieves records using a FetchXML query.
     /// </summary>
     /// <param name="fetchXml">The FetchXML query string.</param>

--- a/src/PowerApps.CLI/Models/ProcessManageModels.cs
+++ b/src/PowerApps.CLI/Models/ProcessManageModels.cs
@@ -23,7 +23,8 @@ public enum ProcessType
     Action = 3,
     BusinessProcessFlow = 4,
     CloudFlow = 5,
-    DuplicateDetectionRule = 100
+    DuplicateDetectionRule = 100,
+    PluginStep = 101
 }
 
 /// <summary>

--- a/src/PowerApps.CLI/PowerApps.CLI.csproj
+++ b/src/PowerApps.CLI/PowerApps.CLI.csproj
@@ -23,6 +23,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>PowerApps.CLI.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.1.32" />
     <PackageReference Include="ClosedXML" Version="0.105.0" />

--- a/src/PowerApps.CLI/Services/ProcessManager.cs
+++ b/src/PowerApps.CLI/Services/ProcessManager.cs
@@ -58,6 +58,24 @@ public class ProcessManager : IProcessManager
             }
         }
 
+        // Retrieve plugin steps — statecode 0 = Enabled (Active), unlike workflows where 1 = Active
+        var pluginStepResults = _client.RetrievePluginSteps(solutions);
+        foreach (var entity in pluginStepResults.Entities)
+        {
+            if (!processes.ContainsKey(entity.Id))
+            {
+                processes[entity.Id] = new ProcessInfo
+                {
+                    Id = entity.Id,
+                    Name = entity.GetAttributeValue<string>("name") ?? "Unknown",
+                    Type = ProcessType.PluginStep,
+                    CurrentState = entity.GetAttributeValue<OptionSetValue>("statecode").Value == 0
+                        ? ProcessState.Active
+                        : ProcessState.Inactive
+                };
+            }
+        }
+
         return processes.Values.ToList();
     }
 
@@ -162,6 +180,8 @@ public class ProcessManager : IProcessManager
                 {
                     if (process.Type == ProcessType.DuplicateDetectionRule)
                         _client.ActivateDuplicateRule(process.Id);
+                    else if (process.Type == ProcessType.PluginStep)
+                        _client.EnablePluginStep(process.Id);
                     else
                         _client.ActivateProcess(process.Id);
 
@@ -172,6 +192,8 @@ public class ProcessManager : IProcessManager
                 {
                     if (process.Type == ProcessType.DuplicateDetectionRule)
                         _client.DeactivateDuplicateRule(process.Id);
+                    else if (process.Type == ProcessType.PluginStep)
+                        _client.DisablePluginStep(process.Id);
                     else
                         _client.DeactivateProcess(process.Id);
 

--- a/src/PowerApps.CLI/Services/ProcessReporter.cs
+++ b/src/PowerApps.CLI/Services/ProcessReporter.cs
@@ -121,6 +121,7 @@ public class ProcessReporter : IProcessReporter
             ProcessType.BusinessProcessFlow => "Business Process Flow",
             ProcessType.CloudFlow => "Cloud Flow",
             ProcessType.DuplicateDetectionRule => "Duplicate Detection Rule",
+            ProcessType.PluginStep => "Plugin Step",
             _ => "Unknown"
         };
     }

--- a/tests/PowerApps.CLI.Tests/Infrastructure/DataverseClientPluginStepTests.cs
+++ b/tests/PowerApps.CLI.Tests/Infrastructure/DataverseClientPluginStepTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Moq;
+using PowerApps.CLI.Infrastructure;
+using Xunit;
+
+namespace PowerApps.CLI.Tests.Infrastructure;
+
+public class DataverseClientPluginStepTests
+{
+    private readonly Mock<IOrganizationService> _mockOrgService;
+    private readonly DataverseClient _client;
+
+    public DataverseClientPluginStepTests()
+    {
+        _mockOrgService = new Mock<IOrganizationService>();
+        _client = new DataverseClient(_mockOrgService.Object);
+    }
+
+    #region RetrievePluginSteps Tests
+
+    [Fact]
+    public void RetrievePluginSteps_WithNoSolutions_QueriesCorrectEntityAndColumns()
+    {
+        // Arrange
+        QueryExpression? capturedQuery = null;
+        _mockOrgService.Setup(s => s.RetrieveMultiple(It.IsAny<QueryBase>()))
+            .Callback<QueryBase>(q => capturedQuery = q as QueryExpression)
+            .Returns(new EntityCollection());
+
+        // Act
+        _client.RetrievePluginSteps(new List<string>());
+
+        // Assert
+        Assert.NotNull(capturedQuery);
+        Assert.Equal("sdkmessageprocessingstep", capturedQuery!.EntityName);
+        Assert.Contains("sdkmessageprocessingstepid", capturedQuery.ColumnSet.Columns);
+        Assert.Contains("name", capturedQuery.ColumnSet.Columns);
+        Assert.Contains("statecode", capturedQuery.ColumnSet.Columns);
+        Assert.Empty(capturedQuery.LinkEntities);
+    }
+
+    [Fact]
+    public void RetrievePluginSteps_WithSolutions_AddsOneLinkPerSolution()
+    {
+        // Arrange
+        QueryExpression? capturedQuery = null;
+        _mockOrgService.Setup(s => s.RetrieveMultiple(It.IsAny<QueryBase>()))
+            .Callback<QueryBase>(q => capturedQuery = q as QueryExpression)
+            .Returns(new EntityCollection());
+
+        // Act
+        _client.RetrievePluginSteps(new List<string> { "SolutionA", "SolutionB" });
+
+        // Assert
+        Assert.NotNull(capturedQuery);
+        Assert.Equal(2, capturedQuery!.LinkEntities.Count);
+    }
+
+    [Fact]
+    public void RetrievePluginSteps_ReturnsClientResult()
+    {
+        // Arrange
+        var stepId = Guid.NewGuid();
+        var entity = new Entity("sdkmessageprocessingstep", stepId);
+        var expected = new EntityCollection(new List<Entity> { entity });
+        _mockOrgService.Setup(s => s.RetrieveMultiple(It.IsAny<QueryBase>())).Returns(expected);
+
+        // Act
+        var result = _client.RetrievePluginSteps(new List<string>());
+
+        // Assert
+        Assert.Same(expected, result);
+    }
+
+    #endregion
+
+    #region EnablePluginStep Tests
+
+    [Fact]
+    public void EnablePluginStep_SendsSetStateRequestWithCorrectValues()
+    {
+        // Arrange
+        var stepId = Guid.NewGuid();
+        SetStateRequest? capturedRequest = null;
+        _mockOrgService.Setup(s => s.Execute(It.IsAny<OrganizationRequest>()))
+            .Callback<OrganizationRequest>(req => capturedRequest = req as SetStateRequest)
+            .Returns(new OrganizationResponse());
+
+        // Act
+        _client.EnablePluginStep(stepId);
+
+        // Assert
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("sdkmessageprocessingstep", capturedRequest!.EntityMoniker.LogicalName);
+        Assert.Equal(stepId, capturedRequest.EntityMoniker.Id);
+        Assert.Equal(0, capturedRequest.State.Value);
+        Assert.Equal(1, capturedRequest.Status.Value);
+    }
+
+    #endregion
+
+    #region DisablePluginStep Tests
+
+    [Fact]
+    public void DisablePluginStep_SendsSetStateRequestWithCorrectValues()
+    {
+        // Arrange
+        var stepId = Guid.NewGuid();
+        SetStateRequest? capturedRequest = null;
+        _mockOrgService.Setup(s => s.Execute(It.IsAny<OrganizationRequest>()))
+            .Callback<OrganizationRequest>(req => capturedRequest = req as SetStateRequest)
+            .Returns(new OrganizationResponse());
+
+        // Act
+        _client.DisablePluginStep(stepId);
+
+        // Assert
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("sdkmessageprocessingstep", capturedRequest!.EntityMoniker.LogicalName);
+        Assert.Equal(stepId, capturedRequest.EntityMoniker.Id);
+        Assert.Equal(1, capturedRequest.State.Value);
+        Assert.Equal(2, capturedRequest.Status.Value);
+    }
+
+    #endregion
+}

--- a/tests/PowerApps.CLI.Tests/Services/ProcessManagerTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/ProcessManagerTests.cs
@@ -17,8 +17,10 @@ public class ProcessManagerTests
     {
         _mockLogger = new Mock<IConsoleLogger>();
         _mockClient = new Mock<IDataverseClient>();
-        // Default: return empty collections so tests that don't care about duplicate rules still work
+        // Default: return empty collections so tests that don't care about these types still work
+        _mockClient.Setup(c => c.RetrieveProcesses(It.IsAny<List<string>>())).Returns(new EntityCollection());
         _mockClient.Setup(c => c.RetrieveDuplicateRules(It.IsAny<List<string>>())).Returns(new EntityCollection());
+        _mockClient.Setup(c => c.RetrievePluginSteps(It.IsAny<List<string>>())).Returns(new EntityCollection());
         _manager = new ProcessManager(_mockLogger.Object, _mockClient.Object);
     }
 
@@ -512,6 +514,178 @@ public class ProcessManagerTests
         entity["name"] = name;
         entity["statecode"] = new OptionSetValue(state == ProcessState.Active ? 1 : 0);
         return entity;
+    }
+
+    // Plugin steps: statecode 0 = Enabled (Active), statecode 1 = Disabled (Inactive)
+    private static Entity CreatePluginStepEntity(Guid id, string name, ProcessState state)
+    {
+        var entity = new Entity("sdkmessageprocessingstep", id);
+        entity["name"] = name;
+        entity["statecode"] = new OptionSetValue(state == ProcessState.Active ? 0 : 1);
+        return entity;
+    }
+
+    #endregion
+
+    #region PluginStep Tests
+
+    [Fact]
+    public void RetrieveProcesses_IncludesPluginSteps()
+    {
+        // Arrange
+        var workflowId = Guid.NewGuid();
+        var stepId = Guid.NewGuid();
+
+        _mockClient.Setup(c => c.RetrieveProcesses(It.IsAny<List<string>>()))
+            .Returns(new EntityCollection(new List<Entity>
+            {
+                CreateProcessEntity(workflowId, "My Workflow", ProcessType.Workflow, ProcessState.Active)
+            }));
+
+        _mockClient.Setup(c => c.RetrievePluginSteps(It.IsAny<List<string>>()))
+            .Returns(new EntityCollection(new List<Entity>
+            {
+                CreatePluginStepEntity(stepId, "My Plugin Step", ProcessState.Active)
+            }));
+
+        // Act
+        var result = _manager.RetrieveProcesses(new List<string> { "MySolution" });
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, p => p.Name == "My Workflow" && p.Type == ProcessType.Workflow);
+        Assert.Contains(result, p => p.Name == "My Plugin Step" && p.Type == ProcessType.PluginStep);
+    }
+
+    [Fact]
+    public void RetrieveProcesses_DeduplicatesPluginSteps()
+    {
+        // Arrange
+        var stepId = Guid.NewGuid();
+
+        _mockClient.Setup(c => c.RetrievePluginSteps(It.IsAny<List<string>>()))
+            .Returns(new EntityCollection(new List<Entity>
+            {
+                CreatePluginStepEntity(stepId, "My Plugin Step", ProcessState.Active),
+                CreatePluginStepEntity(stepId, "My Plugin Step", ProcessState.Active)
+            }));
+
+        // Act
+        var result = _manager.RetrieveProcesses(new List<string>());
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(stepId, result[0].Id);
+    }
+
+    [Fact]
+    public void RetrieveProcesses_MapsPluginStepEnabledStateAsActive()
+    {
+        // Arrange — statecode 0 = Enabled = Active for plugin steps
+        _mockClient.Setup(c => c.RetrievePluginSteps(It.IsAny<List<string>>()))
+            .Returns(new EntityCollection(new List<Entity>
+            {
+                CreatePluginStepEntity(Guid.NewGuid(), "Enabled Step", ProcessState.Active)
+            }));
+
+        // Act
+        var result = _manager.RetrieveProcesses(new List<string>());
+
+        // Assert
+        Assert.Equal(ProcessState.Active, result[0].CurrentState);
+        Assert.Equal(ProcessType.PluginStep, result[0].Type);
+    }
+
+    [Fact]
+    public void RetrieveProcesses_MapsPluginStepDisabledStateAsInactive()
+    {
+        // Arrange — statecode 1 = Disabled = Inactive for plugin steps
+        _mockClient.Setup(c => c.RetrievePluginSteps(It.IsAny<List<string>>()))
+            .Returns(new EntityCollection(new List<Entity>
+            {
+                CreatePluginStepEntity(Guid.NewGuid(), "Disabled Step", ProcessState.Inactive)
+            }));
+
+        // Act
+        var result = _manager.RetrieveProcesses(new List<string>());
+
+        // Assert
+        Assert.Equal(ProcessState.Inactive, result[0].CurrentState);
+    }
+
+    [Fact]
+    public void RetrieveProcesses_PassesSolutionsToPluginStepRetrieval()
+    {
+        // Arrange
+        var solutions = new List<string> { "Solution1", "Solution2" };
+        _mockClient.Setup(c => c.RetrievePluginSteps(solutions)).Returns(new EntityCollection());
+
+        // Act
+        _manager.RetrieveProcesses(solutions);
+
+        // Assert
+        _mockClient.Verify(c => c.RetrievePluginSteps(solutions), Times.Once);
+    }
+
+    [Fact]
+    public void ManageProcessStates_EnablesPluginStepViaCorrectClientMethod()
+    {
+        // Arrange
+        var stepId = Guid.NewGuid();
+        var processes = new List<ProcessInfo>
+        {
+            new() { Id = stepId, Name = "My Plugin Step", Type = ProcessType.PluginStep,
+                    CurrentState = ProcessState.Inactive, ExpectedState = ProcessState.Active }
+        };
+
+        // Act
+        _manager.ManageProcessStates(processes, false, 0);
+
+        // Assert
+        _mockClient.Verify(c => c.EnablePluginStep(stepId), Times.Once);
+        _mockClient.Verify(c => c.ActivateProcess(It.IsAny<Guid>()), Times.Never);
+        _mockClient.Verify(c => c.ActivateDuplicateRule(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public void ManageProcessStates_DisablesPluginStepViaCorrectClientMethod()
+    {
+        // Arrange
+        var stepId = Guid.NewGuid();
+        var processes = new List<ProcessInfo>
+        {
+            new() { Id = stepId, Name = "My Plugin Step", Type = ProcessType.PluginStep,
+                    CurrentState = ProcessState.Active, ExpectedState = ProcessState.Inactive }
+        };
+
+        // Act
+        _manager.ManageProcessStates(processes, false, 0);
+
+        // Assert
+        _mockClient.Verify(c => c.DisablePluginStep(stepId), Times.Once);
+        _mockClient.Verify(c => c.DeactivateProcess(It.IsAny<Guid>()), Times.Never);
+        _mockClient.Verify(c => c.DeactivateDuplicateRule(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public void ManageProcessStates_PluginStep_NoChangeNeeded()
+    {
+        // Arrange
+        var stepId = Guid.NewGuid();
+        var processes = new List<ProcessInfo>
+        {
+            new() { Id = stepId, Name = "Already Enabled Step", Type = ProcessType.PluginStep,
+                    CurrentState = ProcessState.Active, ExpectedState = ProcessState.Active }
+        };
+
+        // Act
+        var summary = _manager.ManageProcessStates(processes, false, 0);
+
+        // Assert
+        _mockClient.Verify(c => c.EnablePluginStep(It.IsAny<Guid>()), Times.Never);
+        _mockClient.Verify(c => c.DisablePluginStep(It.IsAny<Guid>()), Times.Never);
+        Assert.Single(summary.Results);
+        Assert.Equal(ProcessAction.NoChangeNeeded, summary.Results[0].Action);
     }
 
     #endregion


### PR DESCRIPTION
Closes #63

## Summary

- `sdkmessageprocessingstep` records are disabled by default when added via a solution. `process-manage` now retrieves, enables, and reports them alongside workflows, cloud flows, and duplicate detection rules.
- No config changes — `solutions` and `inactivePatterns` apply identically to plugin steps.
- Plugin steps appear in the XLSX report under type **"Plugin Step"**.

## Key design note

Plugin step `statecode` is **inverted** from workflows: `0 = Enabled (Active)`, `1 = Disabled (Inactive)`. Confirmed against the [MS Learn sdkmessageprocessingstep reference](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/reference/entities/sdkmessageprocessingstep). Enable uses `SetStateRequest(State=0, Status=1)`; disable uses `SetStateRequest(State=1, Status=2)`.

## Changes

| File | Change |
|---|---|
| `ProcessManageModels.cs` | `PluginStep = 101` added to `ProcessType` enum |
| `IDataverseClient.cs` | `RetrievePluginSteps`, `EnablePluginStep`, `DisablePluginStep` signatures |
| `DataverseClient.cs` | `IOrganizationService _orgService` field; internal test constructor; 3 new method implementations |
| `PowerApps.CLI.csproj` | `InternalsVisibleTo("PowerApps.CLI.Tests")` to support the internal constructor |
| `ProcessManager.cs` | `RetrievePluginSteps` call with inverted statecode mapping; `EnablePluginStep`/`DisablePluginStep` branches in `ManageProcess` |
| `ProcessReporter.cs` | `PluginStep => "Plugin Step"` in `GetProcessTypeName` |
| `ProcessManagerTests.cs` | Default mock for all 3 retrieve methods; 8 new plugin step tests; `CreatePluginStepEntity` helper |
| `DataverseClientPluginStepTests.cs` | New — 5 tests verifying query structure and `SetStateRequest` parameters |

## Test plan

- [ ] All 375 tests pass (`dotnet test`)
- [ ] `RetrievePluginSteps` query targets `sdkmessageprocessingstep` with correct columns and per-solution join
- [ ] `EnablePluginStep` sends `SetStateRequest` with State=0, Status=1
- [ ] `DisablePluginStep` sends `SetStateRequest` with State=1, Status=2
- [ ] Manager includes, deduplicates, and correctly maps plugin step active/inactive state
- [ ] Manager routes enable/disable to the right client methods (not `ActivateProcess`)
- [ ] No-change path works for already-enabled steps
- [ ] `inactivePatterns` matching applies (inherits from existing `DetermineExpectedStates` — no new logic needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)