### PR TITLE
fix: report image columns as Image instead of Virtual (#69)

### DIFF
--- a/src/PowerApps.CLI/Services/MetadataMapper.cs
+++ b/src/PowerApps.CLI/Services/MetadataMapper.cs
@@ -89,6 +89,12 @@ public class MetadataMapper : IMetadataMapper
         {
             attribute.AttributeType = "File";
         }
+        // ImageAttributeMetadata also reports AttributeTypeCode.Virtual, so the concrete subtype
+        // is the only reliable signal. Derives directly from AttributeMetadata — no ordering hazard.
+        else if (attributeMetadata is ImageAttributeMetadata)
+        {
+            attribute.AttributeType = "Image";
+        }
 
         // Map option sets
         attribute.OptionSet = MapOptionSet(attributeMetadata);

--- a/tests/PowerApps.CLI.Tests/Services/MetadataMapperTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/MetadataMapperTests.cs
@@ -145,6 +145,25 @@ public class MetadataMapperTests
     }
 
     [Fact]
+    public void MapAttribute_ShouldMapImageAttribute()
+    {
+        // Arrange — ImageAttributeMetadata reports AttributeTypeCode.Virtual, so the mapper must
+        // override based on the concrete subtype (regression test for #69).
+        var attributeMetadata = new ImageAttributeMetadata
+        {
+            LogicalName = "xrt_imagefield",
+            SchemaName = "xrt_ImageField"
+        };
+
+        // Act
+        var result = _mapper.MapAttribute(attributeMetadata);
+
+        // Assert
+        Assert.Equal("xrt_imagefield", result.LogicalName);
+        Assert.Equal("Image", result.AttributeType);
+    }
+
+    [Fact]
     public void MapOptionSet_ShouldMapPicklistAttribute()
     {
         // Arrange


### PR DESCRIPTION
Closes #69

## Summary

`ImageAttributeMetadata` exposes `AttributeTypeCode.Virtual` through the base `AttributeType` property, so `MetadataMapper.MapAttribute` exported image columns as `"Virtual"` rather than `"Image"`. This is the same situation already handled for `File` and `MultiSelectPicklist`, where the concrete metadata subtype is the only reliable signal.

## Changes

- Add an `is ImageAttributeMetadata` branch to `MetadataMapper.MapAttribute`, mirroring the existing `FileAttributeMetadata` override. `ImageAttributeMetadata` derives directly from `AttributeMetadata`, so there's no subtype-shadowing ordering hazard.
- Add `MapAttribute_ShouldMapImageAttribute` unit test.

## Context

Surfaced by the integration test scaffolding in #68, where `ExtractSchema_PrimaryTable_MapsAttributeTypesAsync` asserts `xrt_imagefield` → `Image`. That assertion is currently a documented failing test on the #68 branch; it turns green once this fix lands.

## Test plan

- [x] `dotnet test` (unit) — 383 passed, 0 failed (382 existing + 1 new)
- [x] New unit test covers `ImageAttributeMetadata` → `Image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)