### PR TITLE
fix: remove .NET Framework plugin lib from solution (unbreak CI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,4 +192,6 @@ dotnet run --project src/PowerApps.CLI -- [command] [options]
 
 Coverage reports are generated to `tests/coverage/report/index.html`.
 
+> **Plugin lib is not in the solution.** `tests/XRT.IntegrationTestPluginLib` is a .NET Framework 4.7.1, PFX-signed Dynamics plugin assembly used only to exercise `process-manage`'s plugin-step path. The .NET SDK cannot build PFX-signed .NET Framework projects, so it is deliberately **excluded from `PowerApps.CLI.sln`** — including it breaks `dotnet restore`/`build` and CI. Build it separately with full MSBuild / Visual Studio when the assembly needs regenerating; never add it back to the solution.
+
 For integration tests, test scripts, and the integration test solution reference, see [`tests/tests.md`](tests/tests.md).

--- a/PowerApps.CLI.sln
+++ b/PowerApps.CLI.sln
@@ -1,14 +1,13 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.5.11723.231 stable
+VisualStudioVersion = 18.5.11723.231
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerApps.CLI", "src\PowerApps.CLI\PowerApps.CLI.csproj", "{A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerApps.CLI.Tests", "tests\PowerApps.CLI.Tests\PowerApps.CLI.Tests.csproj", "{B2C3D4E5-F6A7-4B5C-9D0E-1F2A3B4C5D6E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0E13E094-A6F0-430F-A339-DB11C9336AF7}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XRT.IntegrationTestPluginLib", "tests\XRT.IntegrationTestPluginLib\XRT.IntegrationTestPluginLib.csproj", "{C1F4B39D-FAC4-4A43-9A59-6EBED58DDB2B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,17 +23,12 @@ Global
 		{B2C3D4E5-F6A7-4B5C-9D0E-1F2A3B4C5D6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B2C3D4E5-F6A7-4B5C-9D0E-1F2A3B4C5D6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B2C3D4E5-F6A7-4B5C-9D0E-1F2A3B4C5D6E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C1F4B39D-FAC4-4A43-9A59-6EBED58DDB2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C1F4B39D-FAC4-4A43-9A59-6EBED58DDB2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C1F4B39D-FAC4-4A43-9A59-6EBED58DDB2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C1F4B39D-FAC4-4A43-9A59-6EBED58DDB2B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B2C3D4E5-F6A7-4B5C-9D0E-1F2A3B4C5D6E} = {0E13E094-A6F0-430F-A339-DB11C9336AF7}
-		{C1F4B39D-FAC4-4A43-9A59-6EBED58DDB2B} = {0E13E094-A6F0-430F-A339-DB11C9336AF7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8F30D906-826D-408B-95CB-8002C76F79B5}


### PR DESCRIPTION
## Problem

`main` is currently broken: `PowerApps.CLI.sln` references `XRT.IntegrationTestPluginLib.csproj`, but that project file is not on `main` (only `ExampleIsAlsoPassword.pfx` was committed via #66). `dotnet restore` therefore fails for any branch off `main`, including open PRs.

Worse, even with the `.csproj` present, the project **cannot be built by the .NET SDK** — it's a .NET Framework 4.7.1, PFX-signed Dynamics plugin assembly, and `dotnet build` rejects PFX signing.

## Fix

- Remove `XRT.IntegrationTestPluginLib` from `PowerApps.CLI.sln`. The plugin source stays in the repo (`tests/XRT.IntegrationTestPluginLib/`) and is built separately with full MSBuild / Visual Studio when the assembly needs regenerating.
- Document the exclusion in `CLAUDE.md` so it isn't accidentally re-added.

## Result

- `dotnet restore` / `dotnet build --configuration Release` succeed locally
- Unblocks CI on `main` and dependent PRs (#70, #68)

## Test plan

- [x] `dotnet restore` — clean
- [x] `dotnet build --no-restore --configuration Release` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)