### PR TITLE
fix: apply --attribute-prefix and --exclude-attributes in schema-export (#72, #73)

### DIFF
--- a/src/PowerApps.CLI/Services/SchemaService.cs
+++ b/src/PowerApps.CLI/Services/SchemaService.cs
@@ -1,4 +1,5 @@
 using PowerApps.CLI.Infrastructure;
+using PowerApps.CLI.Models;
 
 namespace PowerApps.CLI.Services;
 
@@ -53,10 +54,56 @@ public class SchemaService : ISchemaService
 
         _logger.LogSuccess($"✓ Extracted {schema.Entities?.Count ?? 0} entities");
 
+        ApplyAttributeFilters(schema, attributePrefix, excludeAttributes);
+
         // Export schema to file
         _logger.LogInfo($"Writing {format.ToUpperInvariant()} file...");
         await _schemaExporter.ExportAsync(schema, outputPath, format);
 
         _logger.LogSuccess($"✓ Schema exported to {outputPath}");
+    }
+
+    /// <summary>
+    /// Filters each entity's attributes in place by exclusion list and prefix. Semantics mirror
+    /// ConstantsFilter: exclusion (case-insensitive name match) is applied first, then the prefix
+    /// (case-insensitive StartsWith). Both filters apply uniformly to all attributes.
+    /// </summary>
+    private void ApplyAttributeFilters(PowerAppsSchema schema, string? attributePrefix, string? excludeAttributes)
+    {
+        if (schema.Entities == null || schema.Entities.Count == 0)
+        {
+            return;
+        }
+
+        var excludeSet = string.IsNullOrWhiteSpace(excludeAttributes)
+            ? null
+            : new HashSet<string>(
+                excludeAttributes.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+                StringComparer.OrdinalIgnoreCase);
+
+        var hasPrefix = !string.IsNullOrWhiteSpace(attributePrefix);
+
+        if (excludeSet == null && !hasPrefix)
+        {
+            return;
+        }
+
+        foreach (var entity in schema.Entities)
+        {
+            entity.Attributes = entity.Attributes.Where(a =>
+            {
+                if (excludeSet != null && excludeSet.Contains(a.LogicalName))
+                {
+                    return false;
+                }
+
+                if (hasPrefix && !a.LogicalName.StartsWith(attributePrefix!, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                return true;
+            }).ToList();
+        }
     }
 }

--- a/tests/PowerApps.CLI.IntegrationTests/SchemaExport/SchemaExportTests.cs
+++ b/tests/PowerApps.CLI.IntegrationTests/SchemaExport/SchemaExportTests.cs
@@ -293,10 +293,39 @@ public class SchemaExportTests(DataverseFixture fixture)
     }
 
     [SkippableFact]
-    public Task ExtractSchema_AttributePrefix_ReturnsOnlyPrefixedAttributesAsync()
+    public async Task ExtractSchema_AttributePrefix_ReturnsOnlyPrefixedAttributesAsync()
     {
-        Skip.If(true, "Attribute prefix filtering is not implemented — see SchemaService.ExportSchemaAsync.");
-        return Task.CompletedTask;
+        Skip.If(_fixture.ConfigurationError is not null, _fixture.ConfigurationError);
+
+        // Arrange — the prefix filter lives in SchemaService, so this goes through the full
+        // export path rather than the extractor directly.
+        var service = new SchemaService(
+            new ConsoleLogger(),
+            new SchemaExporter(new FileWriter()),
+            _fixture.Client,
+            new SchemaExtractor(new MetadataMapper(), _fixture.Client));
+        var outputPath = Path.Combine(Path.GetTempPath(), $"schema-prefix-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            // Act
+            await service.ExportSchemaAsync(outputPath, "json", IntegrationSolution, attributePrefix: "xrt_");
+            var schema = JsonSerializer.Deserialize<PowerAppsSchema>(await File.ReadAllTextAsync(outputPath));
+
+            // Assert — every column on the primary table is xrt_-prefixed, and the custom columns survived
+            var table = schema!.Entities.Single(e => e.LogicalName == PrimaryTable);
+            Assert.NotEmpty(table.Attributes);
+            Assert.All(table.Attributes, a =>
+                Assert.StartsWith("xrt_", a.LogicalName, StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(table.Attributes, a => a.LogicalName == "xrt_name");
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
     }
 
     [SkippableFact]

--- a/tests/PowerApps.CLI.Tests/Services/SchemaServiceTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/SchemaServiceTests.cs
@@ -1,5 +1,6 @@
 using Moq;
 using PowerApps.CLI.Infrastructure;
+using PowerApps.CLI.Models;
 using PowerApps.CLI.Services;
 using Xunit;
 
@@ -170,6 +171,117 @@ public class SchemaServiceTests
             // Other exceptions (connection errors, etc.) are fine - we only care about format validation
             Assert.True(true);
         }
+    }
+
+    #endregion
+
+    #region Attribute Filter Tests
+
+    [Fact]
+    public async Task ExportSchemaAsync_WithAttributePrefix_FiltersToPrefixedAttributesAsync()
+    {
+        // Arrange
+        var exported = SetupExtractAndCaptureExport(
+            "xrt_name", "xrt_custom", "createdon", "ownerid");
+
+        // Act
+        await _service.ExportSchemaAsync("output.json", "json", attributePrefix: "xrt_");
+
+        // Assert
+        var names = exported().Entities[0].Attributes.Select(a => a.LogicalName);
+        Assert.Equal(new[] { "xrt_name", "xrt_custom" }, names);
+    }
+
+    [Fact]
+    public async Task ExportSchemaAsync_WithAttributePrefix_IsCaseInsensitiveAsync()
+    {
+        // Arrange
+        var exported = SetupExtractAndCaptureExport("XRT_Name", "createdon");
+
+        // Act
+        await _service.ExportSchemaAsync("output.json", "json", attributePrefix: "xrt_");
+
+        // Assert
+        var names = exported().Entities[0].Attributes.Select(a => a.LogicalName);
+        Assert.Equal(new[] { "XRT_Name" }, names);
+    }
+
+    [Fact]
+    public async Task ExportSchemaAsync_WithExcludeAttributes_RemovesExcludedAttributesAsync()
+    {
+        // Arrange
+        var exported = SetupExtractAndCaptureExport(
+            "xrt_name", "createdon", "modifiedon", "ownerid");
+
+        // Act
+        await _service.ExportSchemaAsync("output.json", "json", excludeAttributes: "createdon, MODIFIEDON");
+
+        // Assert — case-insensitive, whitespace-trimmed
+        var names = exported().Entities[0].Attributes.Select(a => a.LogicalName);
+        Assert.Equal(new[] { "xrt_name", "ownerid" }, names);
+    }
+
+    [Fact]
+    public async Task ExportSchemaAsync_WithBothFilters_AppliesExcludeAndPrefixAsync()
+    {
+        // Arrange
+        var exported = SetupExtractAndCaptureExport(
+            "xrt_name", "xrt_secret", "createdon");
+
+        // Act — prefix keeps xrt_*, exclude drops xrt_secret
+        await _service.ExportSchemaAsync(
+            "output.json", "json", attributePrefix: "xrt_", excludeAttributes: "xrt_secret");
+
+        // Assert
+        var names = exported().Entities[0].Attributes.Select(a => a.LogicalName);
+        Assert.Equal(new[] { "xrt_name" }, names);
+    }
+
+    [Fact]
+    public async Task ExportSchemaAsync_WithNoFilters_KeepsAllAttributesAsync()
+    {
+        // Arrange
+        var exported = SetupExtractAndCaptureExport("xrt_name", "createdon", "ownerid");
+
+        // Act
+        await _service.ExportSchemaAsync("output.json", "json");
+
+        // Assert
+        var names = exported().Entities[0].Attributes.Select(a => a.LogicalName);
+        Assert.Equal(new[] { "xrt_name", "createdon", "ownerid" }, names);
+    }
+
+    /// <summary>
+    /// Wires the extractor to return a single-entity schema with the given attribute logical names
+    /// and captures the schema handed to the exporter. Returns an accessor for that captured schema.
+    /// </summary>
+    private Func<PowerAppsSchema> SetupExtractAndCaptureExport(params string[] attributeLogicalNames)
+    {
+        var schema = new PowerAppsSchema
+        {
+            Entities = new List<EntitySchema>
+            {
+                new()
+                {
+                    LogicalName = "xrt_integrationtest",
+                    Attributes = attributeLogicalNames
+                        .Select(n => new AttributeSchema { LogicalName = n })
+                        .ToList()
+                }
+            }
+        };
+
+        _mockSchemaExtractor
+            .Setup(e => e.ExtractSchemaAsync(It.IsAny<string?>()))
+            .ReturnsAsync(schema);
+
+        PowerAppsSchema? captured = null;
+        _mockSchemaExporter
+            .Setup(e => e.ExportAsync(It.IsAny<PowerAppsSchema>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<PowerAppsSchema, string, string>((s, _, _) => captured = s)
+            .Returns(Task.CompletedTask);
+
+        return () => captured ?? throw new InvalidOperationException("Export was not invoked.");
     }
 
     #endregion


### PR DESCRIPTION
Closes #72
Closes #73

## Problem

`schema-export` accepted `--attribute-prefix` and `--exclude-attributes`, and both flowed through to `SchemaService.ExportSchemaAsync`, but the method never used either parameter — they were silently dropped. A user filtering by prefix or exclusion got the full unfiltered schema, despite the verbose log claiming the filter was applied.

## Fix

Add an `ApplyAttributeFilters` step in `SchemaService.ExportSchemaAsync` (after extraction, before export) that filters each entity's attributes in place. Semantics mirror the existing `ConstantsFilter`:

- **Exclude** first — case-insensitive `HashSet` match on `LogicalName` (comma-separated, whitespace-trimmed)
- **Prefix** next — case-insensitive `StartsWith`
- Applied uniformly to all attributes (no special-casing of primary id/name; on a custom table the prefixed keys survive anyway)

`ISchemaExtractor` is unchanged — the filter is an export-layer concern and the parameters already lived on `SchemaService`.

## Tests

- **Unit** (`SchemaServiceTests`, 5 new): prefix-only, exclude-only, both together, prefix case-insensitivity, and no-filter pass-through. Uses a mocked extractor + a capture of the schema handed to the exporter.
- **Integration**: unskipped `ExtractSchema_AttributePrefix_ReturnsOnlyPrefixedAttributesAsync` — now routes through `SchemaService` → JSON file → read back, asserting every column on `xrt_integrationtest` is `xrt_`-prefixed and the custom columns survived.

## Test plan

- [x] `dotnet test` (unit) — 388 passed (383 + 5)
- [x] `dotnet test --filter "Category=Integration"` — 16 passed, **0 skipped** (was 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)