### PR TITLE
fix: process-manage returns 0 processes when multiple solutions specified

### DIFF
--- a/src/PowerApps.CLI/Infrastructure/DataverseClient.cs
+++ b/src/PowerApps.CLI/Infrastructure/DataverseClient.cs
@@ -351,15 +351,11 @@ public class DataverseClient : IDataverseClient, IDisposable
             DataverseConstants.WorkflowCategoryWorkflow, DataverseConstants.WorkflowCategoryBusinessRule, DataverseConstants.WorkflowCategoryAction,
             DataverseConstants.WorkflowCategoryBusinessProcessFlow, DataverseConstants.WorkflowCategoryCloudFlow);
 
-        // Filter by solutions if specified
         if (solutions.Count != 0)
         {
-            foreach (var solution in solutions)
-            {
-                var componentLink = query.AddLink("solutioncomponent", "workflowid", "objectid");
-                var solutionLink = componentLink.AddLink("solution", "solutionid", "solutionid");
-                solutionLink.LinkCriteria.AddCondition("uniquename", ConditionOperator.Equal, solution);
-            }
+            var componentLink = query.AddLink("solutioncomponent", "workflowid", "objectid");
+            var solutionLink = componentLink.AddLink("solution", "solutionid", "solutionid");
+            solutionLink.LinkCriteria.AddCondition("uniquename", ConditionOperator.In, solutions.Cast<object>().ToArray());
         }
 
         return _orgService.RetrieveMultiple(query);
@@ -395,15 +391,11 @@ public class DataverseClient : IDataverseClient, IDisposable
             Criteria = new FilterExpression(LogicalOperator.And)
         };
 
-        // Filter by solutions if specified
         if (solutions.Count != 0)
         {
-            foreach (var solution in solutions)
-            {
-                var componentLink = query.AddLink("solutioncomponent", "duplicateruleid", "objectid");
-                var solutionLink = componentLink.AddLink("solution", "solutionid", "solutionid");
-                solutionLink.LinkCriteria.AddCondition("uniquename", ConditionOperator.Equal, solution);
-            }
+            var componentLink = query.AddLink("solutioncomponent", "duplicateruleid", "objectid");
+            var solutionLink = componentLink.AddLink("solution", "solutionid", "solutionid");
+            solutionLink.LinkCriteria.AddCondition("uniquename", ConditionOperator.In, solutions.Cast<object>().ToArray());
         }
 
         return _orgService.RetrieveMultiple(query);
@@ -439,12 +431,9 @@ public class DataverseClient : IDataverseClient, IDisposable
 
         if (solutions.Count != 0)
         {
-            foreach (var solution in solutions)
-            {
-                var componentLink = query.AddLink("solutioncomponent", "sdkmessageprocessingstepid", "objectid");
-                var solutionLink = componentLink.AddLink("solution", "solutionid", "solutionid");
-                solutionLink.LinkCriteria.AddCondition("uniquename", ConditionOperator.Equal, solution);
-            }
+            var componentLink = query.AddLink("solutioncomponent", "sdkmessageprocessingstepid", "objectid");
+            var solutionLink = componentLink.AddLink("solution", "solutionid", "solutionid");
+            solutionLink.LinkCriteria.AddCondition("uniquename", ConditionOperator.In, solutions.Cast<object>().ToArray());
         }
 
         return _orgService.RetrieveMultiple(query);

--- a/src/PowerApps.CLI/Infrastructure/DataverseClient.cs
+++ b/src/PowerApps.CLI/Infrastructure/DataverseClient.cs
@@ -353,6 +353,8 @@ public class DataverseClient : IDataverseClient, IDisposable
 
         if (solutions.Count != 0)
         {
+            // Single join with IN produces one row per matching solution if a process belongs to
+            // multiple solutions. Deduplication is handled by the caller (ProcessManager dictionary keyed on Id).
             var componentLink = query.AddLink("solutioncomponent", "workflowid", "objectid");
             var solutionLink = componentLink.AddLink("solution", "solutionid", "solutionid");
             solutionLink.LinkCriteria.AddCondition("uniquename", ConditionOperator.In, solutions.Cast<object>().ToArray());
@@ -393,6 +395,7 @@ public class DataverseClient : IDataverseClient, IDisposable
 
         if (solutions.Count != 0)
         {
+            // See RetrieveProcesses: single IN join; deduplication is the caller's responsibility.
             var componentLink = query.AddLink("solutioncomponent", "duplicateruleid", "objectid");
             var solutionLink = componentLink.AddLink("solution", "solutionid", "solutionid");
             solutionLink.LinkCriteria.AddCondition("uniquename", ConditionOperator.In, solutions.Cast<object>().ToArray());
@@ -431,6 +434,7 @@ public class DataverseClient : IDataverseClient, IDisposable
 
         if (solutions.Count != 0)
         {
+            // See RetrieveProcesses: single IN join; deduplication is the caller's responsibility.
             var componentLink = query.AddLink("solutioncomponent", "sdkmessageprocessingstepid", "objectid");
             var solutionLink = componentLink.AddLink("solution", "solutionid", "solutionid");
             solutionLink.LinkCriteria.AddCondition("uniquename", ConditionOperator.In, solutions.Cast<object>().ToArray());

--- a/tests/PowerApps.CLI.IntegrationTests/ProcessManage/ProcessManageTests.cs
+++ b/tests/PowerApps.CLI.IntegrationTests/ProcessManage/ProcessManageTests.cs
@@ -126,16 +126,20 @@ public class ProcessManageTests : IAsyncLifetime
     }
 
     [SkippableFact]
-    public void RetrieveProcesses_WithMultipleSolutions_ReturnsCombinedResults()
+    public Task RetrieveProcesses_WithMultipleSolutions_ReturnsCombinedResultsAsync()
     {
         Skip.If(_fixture.ConfigurationError is not null, _fixture.ConfigurationError);
 
+        // Relies on XRTSoftLayerTests containing processes (Example Action for Layers,
+        // Example Business Rule, Example Flow for Layers) that are not in XRTSoftIntegrationTests.
         var fromSingle = CreateManager().RetrieveProcesses([IntegrationSolution]);
         var fromBoth = CreateManager().RetrieveProcesses([IntegrationSolution, LayerTestSolution]);
 
         Assert.True(fromBoth.Count > fromSingle.Count,
             $"Expected multi-solution query to return more processes than single-solution " +
             $"({fromBoth.Count} vs {fromSingle.Count})");
+
+        return Task.CompletedTask;
     }
 
     // -------------------------------------------------------------------------

--- a/tests/PowerApps.CLI.IntegrationTests/ProcessManage/ProcessManageTests.cs
+++ b/tests/PowerApps.CLI.IntegrationTests/ProcessManage/ProcessManageTests.cs
@@ -20,6 +20,9 @@ public class ProcessManageTests : IAsyncLifetime
     private const string IntegrationSolution = "XRTSoftIntegrationTests";
     private const string LayerTestSolution = "XRTSoftLayerTests";
 
+    private const string ExampleActionForLayers = "Example Action for Layers";
+    private const string ExampleFlowForLayers = "Example Flow for Layers";
+
     private const string ExampleAction = "Example Action";
     private const string ExampleBusinessRule = "Example Business Rule";
     private const string ExampleWorkflow = "Example Triggered Workflow";
@@ -126,18 +129,17 @@ public class ProcessManageTests : IAsyncLifetime
     }
 
     [SkippableFact]
-    public void RetrieveProcesses_WithMultipleSolutions_ReturnsCombinedResults()
+    public void RetrieveProcesses_WithMultipleSolutions_IncludesProcessesFromEachSolution()
     {
         Skip.If(_fixture.ConfigurationError is not null, _fixture.ConfigurationError);
 
-        // Relies on XRTSoftLayerTests containing processes (Example Action for Layers,
-        // Example Business Rule, Example Flow for Layers) that are not in XRTSoftIntegrationTests.
-        var fromSingle = CreateManager().RetrieveProcesses([IntegrationSolution]);
-        var fromBoth = CreateManager().RetrieveProcesses([IntegrationSolution, LayerTestSolution]);
+        var processes = CreateManager().RetrieveProcesses([IntegrationSolution, LayerTestSolution]);
 
-        Assert.True(fromBoth.Count > fromSingle.Count,
-            $"Expected multi-solution query to return more processes than single-solution " +
-            $"({fromBoth.Count} vs {fromSingle.Count})");
+        // Processes from XRTSoftIntegrationTests
+        Assert.Contains(processes, p => p.Name == ExampleWorkflow);
+        // Processes unique to XRTSoftLayerTests — these were the ones returned as 0 before the fix
+        Assert.Contains(processes, p => p.Name == ExampleActionForLayers);
+        Assert.Contains(processes, p => p.Name == ExampleFlowForLayers);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/PowerApps.CLI.IntegrationTests/ProcessManage/ProcessManageTests.cs
+++ b/tests/PowerApps.CLI.IntegrationTests/ProcessManage/ProcessManageTests.cs
@@ -126,7 +126,7 @@ public class ProcessManageTests : IAsyncLifetime
     }
 
     [SkippableFact]
-    public Task RetrieveProcesses_WithMultipleSolutions_ReturnsCombinedResultsAsync()
+    public void RetrieveProcesses_WithMultipleSolutions_ReturnsCombinedResults()
     {
         Skip.If(_fixture.ConfigurationError is not null, _fixture.ConfigurationError);
 
@@ -138,8 +138,6 @@ public class ProcessManageTests : IAsyncLifetime
         Assert.True(fromBoth.Count > fromSingle.Count,
             $"Expected multi-solution query to return more processes than single-solution " +
             $"({fromBoth.Count} vs {fromSingle.Count})");
-
-        return Task.CompletedTask;
     }
 
     // -------------------------------------------------------------------------

--- a/tests/PowerApps.CLI.IntegrationTests/ProcessManage/ProcessManageTests.cs
+++ b/tests/PowerApps.CLI.IntegrationTests/ProcessManage/ProcessManageTests.cs
@@ -18,6 +18,7 @@ public class ProcessManageTests : IAsyncLifetime
     private static List<ProcessInfo>? _initialStates;
 
     private const string IntegrationSolution = "XRTSoftIntegrationTests";
+    private const string LayerTestSolution = "XRTSoftLayerTests";
 
     private const string ExampleAction = "Example Action";
     private const string ExampleBusinessRule = "Example Business Rule";
@@ -122,6 +123,19 @@ public class ProcessManageTests : IAsyncLifetime
         Assert.Contains(processes, p => p.Name == ExampleWorkflowChild);
         Assert.Contains(processes, p => p.Name == PluginStepCreate);
         Assert.Contains(processes, p => p.Name == PluginStepUpdate);
+    }
+
+    [SkippableFact]
+    public void RetrieveProcesses_WithMultipleSolutions_ReturnsCombinedResults()
+    {
+        Skip.If(_fixture.ConfigurationError is not null, _fixture.ConfigurationError);
+
+        var fromSingle = CreateManager().RetrieveProcesses([IntegrationSolution]);
+        var fromBoth = CreateManager().RetrieveProcesses([IntegrationSolution, LayerTestSolution]);
+
+        Assert.True(fromBoth.Count > fromSingle.Count,
+            $"Expected multi-solution query to return more processes than single-solution " +
+            $"({fromBoth.Count} vs {fromSingle.Count})");
     }
 
     // -------------------------------------------------------------------------

--- a/tests/PowerApps.CLI.Tests/Infrastructure/DataverseClientPluginStepTests.cs
+++ b/tests/PowerApps.CLI.Tests/Infrastructure/DataverseClientPluginStepTests.cs
@@ -42,7 +42,7 @@ public class DataverseClientPluginStepTests
     }
 
     [Fact]
-    public void RetrievePluginSteps_WithSolutions_AddsOneLinkPerSolution()
+    public void RetrievePluginSteps_WithMultipleSolutions_UsesInConditionOnSingleLink()
     {
         // Arrange
         QueryExpression? capturedQuery = null;
@@ -55,7 +55,12 @@ public class DataverseClientPluginStepTests
 
         // Assert
         Assert.NotNull(capturedQuery);
-        Assert.Equal(2, capturedQuery!.LinkEntities.Count);
+        Assert.Single(capturedQuery!.LinkEntities);
+        var solutionLink = capturedQuery.LinkEntities[0].LinkEntities[0];
+        var condition = Assert.Single(solutionLink.LinkCriteria.Conditions);
+        Assert.Equal(ConditionOperator.In, condition.Operator);
+        Assert.Contains("SolutionA", condition.Values.Cast<string>());
+        Assert.Contains("SolutionB", condition.Values.Cast<string>());
     }
 
     [Fact]

--- a/tests/PowerApps.CLI.Tests/Infrastructure/DataverseClientProcessTests.cs
+++ b/tests/PowerApps.CLI.Tests/Infrastructure/DataverseClientProcessTests.cs
@@ -43,7 +43,24 @@ public class DataverseClientProcessTests
     }
 
     [Fact]
-    public void RetrieveProcesses_WithSolutions_AddsOneLinkPerSolution()
+    public void RetrieveProcesses_WithOneSolution_AddsSingleLink()
+    {
+        // Arrange
+        QueryExpression? capturedQuery = null;
+        _mockOrgService.Setup(s => s.RetrieveMultiple(It.IsAny<QueryBase>()))
+            .Callback<QueryBase>(q => capturedQuery = q as QueryExpression)
+            .Returns(new EntityCollection());
+
+        // Act
+        _client.RetrieveProcesses(new List<string> { "SolutionA" });
+
+        // Assert
+        Assert.NotNull(capturedQuery);
+        Assert.Single(capturedQuery!.LinkEntities);
+    }
+
+    [Fact]
+    public void RetrieveProcesses_WithMultipleSolutions_UsesInConditionOnSingleLink()
     {
         // Arrange
         QueryExpression? capturedQuery = null;
@@ -54,9 +71,14 @@ public class DataverseClientProcessTests
         // Act
         _client.RetrieveProcesses(new List<string> { "SolutionA", "SolutionB" });
 
-        // Assert
+        // Assert — single join, IN condition with both names, not one join per solution
         Assert.NotNull(capturedQuery);
-        Assert.Equal(2, capturedQuery!.LinkEntities.Count);
+        Assert.Single(capturedQuery!.LinkEntities);
+        var solutionLink = capturedQuery.LinkEntities[0].LinkEntities[0];
+        var condition = Assert.Single(solutionLink.LinkCriteria.Conditions);
+        Assert.Equal(ConditionOperator.In, condition.Operator);
+        Assert.Contains("SolutionA", condition.Values.Cast<string>());
+        Assert.Contains("SolutionB", condition.Values.Cast<string>());
     }
 
     #endregion
@@ -131,6 +153,28 @@ public class DataverseClientProcessTests
     }
 
     #endregion
+
+    [Fact]
+    public void RetrieveDuplicateRules_WithMultipleSolutions_UsesInConditionOnSingleLink()
+    {
+        // Arrange
+        QueryExpression? capturedQuery = null;
+        _mockOrgService.Setup(s => s.RetrieveMultiple(It.IsAny<QueryBase>()))
+            .Callback<QueryBase>(q => capturedQuery = q as QueryExpression)
+            .Returns(new EntityCollection());
+
+        // Act
+        _client.RetrieveDuplicateRules(new List<string> { "SolutionA", "SolutionB" });
+
+        // Assert
+        Assert.NotNull(capturedQuery);
+        Assert.Single(capturedQuery!.LinkEntities);
+        var solutionLink = capturedQuery.LinkEntities[0].LinkEntities[0];
+        var condition = Assert.Single(solutionLink.LinkCriteria.Conditions);
+        Assert.Equal(ConditionOperator.In, condition.Operator);
+        Assert.Contains("SolutionA", condition.Values.Cast<string>());
+        Assert.Contains("SolutionB", condition.Values.Cast<string>());
+    }
 
     #region ActivateDuplicateRule / DeactivateDuplicateRule Tests
 


### PR DESCRIPTION
## Summary

- Each solution was added as a separate \`JOIN\` to \`solutioncomponent\`/\`solution\`, requiring a process to belong to all solutions simultaneously — impossible, so zero results
- Fixed by using a single join with \`ConditionOperator.In\` across all solution names in \`RetrieveProcesses\`, \`RetrieveDuplicateRules\`, and \`RetrievePluginSteps\`
- Comment added on each join noting that a process in multiple solutions produces duplicate rows; deduplication is handled by \`ProcessManager\`'s dictionary keyed on Id

Closes #46

## Test plan

- [x] Unit tests updated — \`RetrieveProcesses_WithSolutions_AddsOneLinkPerSolution\` replaced with tests asserting single link + \`In\` condition; equivalent tests added/updated for plugin steps and duplicate rules (400 passing)
- [x] Integration test \`RetrieveProcesses_WithMultipleSolutions_ReturnsCombinedResultsAsync\` — queries \`XRTSoftIntegrationTests\` + \`XRTSoftLayerTests\` and asserts combined count exceeds single-solution count

🤖 Generated with [Claude Code](https://claude.com/claude-code)