### PR TITLE
perf(solution-layers): pre-filter Phase 2 via Active solution membership

### DIFF
--- a/src/PowerApps.CLI/Infrastructure/DataverseClient.cs
+++ b/src/PowerApps.CLI/Infrastructure/DataverseClient.cs
@@ -692,11 +692,13 @@ public class DataverseClient : IDataverseClient, IDisposable
         // Phase 1d: cross-reference against the Active solution before Phase 2. Only components
         // with a real solutioncomponent row in the Active (unmanaged customisations) solution can
         // possibly have an unmanaged layer, so filtering here avoids querying msdyn_componentlayer
-        // for components that were never customised.
-        var activeIds = await GetActiveSolutionComponentIdsAsync();
+        // for components that were never customised. Scoped to this solution's candidate IDs
+        // (batched) rather than the whole Active bucket, so cost scales with the target solution's
+        // size rather than the org's entire unmanaged-customisation history.
         var beforeFilterCount = componentList.Count;
+        var activeIds = await GetActiveSolutionComponentIdsAsync(componentList.Select(c => c.Id).ToList());
         componentList = componentList.Where(c => activeIds.Contains(c.Id)).ToList();
-        phaseLog?.Invoke($"Phase 1d ({sw.ElapsedMilliseconds}ms): filtered {beforeFilterCount} component(s) to {componentList.Count} present in the Active solution.");
+        phaseLog?.Invoke($"Phase 1d ({sw.ElapsedMilliseconds}ms): checked {beforeFilterCount} candidate(s) against Active, {componentList.Count} present.");
         sw.Restart();
 
         // Phase 2: batch individual msdyn_componentlayer queries into ExecuteMultiple calls.
@@ -816,52 +818,64 @@ public class DataverseClient : IDataverseClient, IDisposable
         return allLayers;
     }
 
-    // Queries solutioncomponent joined to the "Active" solution to get the set of component
-    // object IDs that have a real unmanaged-customisation record. Used to pre-filter the Phase 2
-    // candidate list — see GetSolutionComponentLayersAsync.
-    private async Task<HashSet<Guid>> GetActiveSolutionComponentIdsAsync()
+    // Queries solutioncomponent joined to the "Active" solution to get the subset of the given
+    // candidate IDs that have a real unmanaged-customisation record. Used to pre-filter the
+    // Phase 2 candidate list — see GetSolutionComponentLayersAsync. Batched by objectid so query
+    // cost scales with the candidate list (the target solution's component count) rather than the
+    // org's entire Active-solution history.
+    private const int ActiveSolutionLookupBatchSize = 500;
+
+    private async Task<HashSet<Guid>> GetActiveSolutionComponentIdsAsync(IReadOnlyList<Guid> candidateIds)
     {
-        var query = new QueryExpression("solutioncomponent")
+        var ids = new HashSet<Guid>();
+
+        foreach (var chunk in candidateIds.Chunk(ActiveSolutionLookupBatchSize))
         {
-            ColumnSet = new ColumnSet("objectid"),
-            NoLock = true,
-            LinkEntities =
+            var query = new QueryExpression("solutioncomponent")
             {
-                new LinkEntity
+                ColumnSet = new ColumnSet("objectid"),
+                NoLock = true,
+                Criteria = new FilterExpression
                 {
-                    LinkFromEntityName = "solutioncomponent",
-                    LinkFromAttributeName = "solutionid",
-                    LinkToEntityName = "solution",
-                    LinkToAttributeName = "solutionid",
-                    LinkCriteria = new FilterExpression
+                    Conditions = { new ConditionExpression("objectid", ConditionOperator.In, chunk.Cast<object>().ToArray()) }
+                },
+                LinkEntities =
+                {
+                    new LinkEntity
                     {
-                        Conditions = { new ConditionExpression("uniquename", ConditionOperator.Equal, DataverseConstants.ActiveSolutionUniqueName) }
+                        LinkFromEntityName = "solutioncomponent",
+                        LinkFromAttributeName = "solutionid",
+                        LinkToEntityName = "solution",
+                        LinkToAttributeName = "solutionid",
+                        LinkCriteria = new FilterExpression
+                        {
+                            Conditions = { new ConditionExpression("uniquename", ConditionOperator.Equal, DataverseConstants.ActiveSolutionUniqueName) }
+                        }
+                    }
+                },
+                PageInfo = new PagingInfo { Count = 5000, PageNumber = 1 }
+            };
+
+            EntityCollection page;
+            do
+            {
+                page = await Task.Run(() => _orgService.RetrieveMultiple(query));
+                foreach (var e in page.Entities)
+                {
+                    var id = e.GetAttributeValue<Guid>("objectid");
+                    if (id != Guid.Empty)
+                    {
+                        ids.Add(id);
                     }
                 }
-            },
-            PageInfo = new PagingInfo { Count = 5000, PageNumber = 1 }
-        };
 
-        var ids = new HashSet<Guid>();
-        EntityCollection page;
-        do
-        {
-            page = await Task.Run(() => _orgService.RetrieveMultiple(query));
-            foreach (var e in page.Entities)
-            {
-                var id = e.GetAttributeValue<Guid>("objectid");
-                if (id != Guid.Empty)
+                if (page.MoreRecords)
                 {
-                    ids.Add(id);
+                    query.PageInfo.PageNumber++;
+                    query.PageInfo.PagingCookie = page.PagingCookie;
                 }
-            }
-
-            if (page.MoreRecords)
-            {
-                query.PageInfo.PageNumber++;
-                query.PageInfo.PagingCookie = page.PagingCookie;
-            }
-        } while (page.MoreRecords);
+            } while (page.MoreRecords);
+        }
 
         return ids;
     }

--- a/src/PowerApps.CLI/Infrastructure/DataverseClient.cs
+++ b/src/PowerApps.CLI/Infrastructure/DataverseClient.cs
@@ -689,6 +689,16 @@ public class DataverseClient : IDataverseClient, IDisposable
         phaseLog?.Invoke($"Phase 1c ({sw.ElapsedMilliseconds}ms): expanded to {componentList.Count} component(s) after form/view/chart enumeration.");
         sw.Restart();
 
+        // Phase 1d: cross-reference against the Active solution before Phase 2. Only components
+        // with a real solutioncomponent row in the Active (unmanaged customisations) solution can
+        // possibly have an unmanaged layer, so filtering here avoids querying msdyn_componentlayer
+        // for components that were never customised.
+        var activeIds = await GetActiveSolutionComponentIdsAsync();
+        var beforeFilterCount = componentList.Count;
+        componentList = componentList.Where(c => activeIds.Contains(c.Id)).ToList();
+        phaseLog?.Invoke($"Phase 1d ({sw.ElapsedMilliseconds}ms): filtered {beforeFilterCount} component(s) to {componentList.Count} present in the Active solution.");
+        sw.Restart();
+
         // Phase 2: batch individual msdyn_componentlayer queries into ExecuteMultiple calls.
         // msdyn_componentlayer requires exactly one msdyn_componentid per query (IN clauses
         // are silently ignored by the virtual entity provider), so we pack batchSize individual
@@ -724,7 +734,12 @@ public class DataverseClient : IDataverseClient, IDisposable
                     Query = new QueryExpression("msdyn_componentlayer")
                     {
                         NoLock = true,
-                        ColumnSet = new ColumnSet(true),
+                        ColumnSet = new ColumnSet(
+                            "msdyn_componentid",
+                            "msdyn_order",
+                            "msdyn_solutionname",
+                            "msdyn_name",
+                            "msdyn_solutioncomponentname"),
                         Criteria = new FilterExpression
                         {
                             Conditions =
@@ -799,6 +814,56 @@ public class DataverseClient : IDataverseClient, IDisposable
         var allLayers = new EntityCollection();
         allLayers.Entities.AddRange(layerBag);
         return allLayers;
+    }
+
+    // Queries solutioncomponent joined to the "Active" solution to get the set of component
+    // object IDs that have a real unmanaged-customisation record. Used to pre-filter the Phase 2
+    // candidate list — see GetSolutionComponentLayersAsync.
+    private async Task<HashSet<Guid>> GetActiveSolutionComponentIdsAsync()
+    {
+        var query = new QueryExpression("solutioncomponent")
+        {
+            ColumnSet = new ColumnSet("objectid"),
+            NoLock = true,
+            LinkEntities =
+            {
+                new LinkEntity
+                {
+                    LinkFromEntityName = "solutioncomponent",
+                    LinkFromAttributeName = "solutionid",
+                    LinkToEntityName = "solution",
+                    LinkToAttributeName = "solutionid",
+                    LinkCriteria = new FilterExpression
+                    {
+                        Conditions = { new ConditionExpression("uniquename", ConditionOperator.Equal, DataverseConstants.ActiveSolutionUniqueName) }
+                    }
+                }
+            },
+            PageInfo = new PagingInfo { Count = 5000, PageNumber = 1 }
+        };
+
+        var ids = new HashSet<Guid>();
+        EntityCollection page;
+        do
+        {
+            page = await Task.Run(() => _orgService.RetrieveMultiple(query));
+            foreach (var e in page.Entities)
+            {
+                var id = e.GetAttributeValue<Guid>("objectid");
+                if (id != Guid.Empty)
+                {
+                    ids.Add(id);
+                }
+            }
+
+            if (page.MoreRecords)
+            {
+                query.PageInfo.PageNumber++;
+                query.PageInfo.PagingCookie = page.PagingCookie;
+            }
+        } while (page.MoreRecords);
+
+        return ids;
     }
 
     // Queries solutioncomponentdefinition to get the msdyn_solutioncomponentname routing key

--- a/src/PowerApps.CLI/Models/DataverseConstants.cs
+++ b/src/PowerApps.CLI/Models/DataverseConstants.cs
@@ -15,6 +15,9 @@ internal static class DataverseConstants
     internal const int ComponentTypeSavedQueryVisualization = 59;
     internal const int ComponentTypeSystemForm = 60;
 
+    // The "Active" solution is Dataverse's built-in bucket for unmanaged customisations.
+    internal const string ActiveSolutionUniqueName = "Active";
+
     // workflow.category option set codes.
     internal const int WorkflowCategoryWorkflow = 0;
     internal const int WorkflowCategoryBusinessRule = 2;

--- a/src/PowerApps.CLI/Services/SolutionLayerService.cs
+++ b/src/PowerApps.CLI/Services/SolutionLayerService.cs
@@ -40,7 +40,7 @@ public class SolutionLayerService : ISolutionLayerService
             var topSolutionName = topLayer.GetAttributeValue<string>("msdyn_solutionname") ?? string.Empty;
 
             // "Active" is the unmanaged customisations bucket in Dataverse.
-            if (!topSolutionName.Equals("Active", StringComparison.OrdinalIgnoreCase))
+            if (!topSolutionName.Equals(DataverseConstants.ActiveSolutionUniqueName, StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }
@@ -49,7 +49,7 @@ public class SolutionLayerService : ISolutionLayerService
             // fields that were never part of any managed solution layer. We only care about
             // Active layers sitting on top of a managed layer.
             var hasNonActiveLayer = group.Any(e => !string.Equals(
-                e.GetAttributeValue<string>("msdyn_solutionname"), "Active", StringComparison.OrdinalIgnoreCase));
+                e.GetAttributeValue<string>("msdyn_solutionname"), DataverseConstants.ActiveSolutionUniqueName, StringComparison.OrdinalIgnoreCase));
             if (!hasNonActiveLayer)
             {
                 continue;

--- a/tests/PowerApps.CLI.Tests/Infrastructure/DataverseClientSolutionLayerTests.cs
+++ b/tests/PowerApps.CLI.Tests/Infrastructure/DataverseClientSolutionLayerTests.cs
@@ -48,6 +48,12 @@ public class DataverseClientSolutionLayerTests
         return (string)condition.Values[0];
     }
 
+    private static List<Guid> GetQueriedObjectIds(QueryExpression query)
+    {
+        var condition = query.Criteria.Conditions.Single(c => c.AttributeName == "objectid");
+        return condition.Values.Cast<Guid>().ToList();
+    }
+
     /// <summary>
     /// Wires up RetrieveMultiple to dispatch based on query shape: Phase 1's solutioncomponent
     /// query (joined to the target solution), Phase 1d's solutioncomponent query (joined to
@@ -135,6 +141,37 @@ public class DataverseClientSolutionLayerTests
         Assert.Equal("uniquename", condition.AttributeName);
         Assert.Equal(ConditionOperator.Equal, condition.Operator);
         Assert.Equal("Active", condition.Values[0]);
+
+        // The Active-solution lookup must be scoped to this run's candidate IDs, not the
+        // whole Active bucket, so cost scales with the target solution rather than the org.
+        var objectIdCondition = Assert.Single(activeQuery.Criteria.Conditions);
+        Assert.Equal("objectid", objectIdCondition.AttributeName);
+        Assert.Equal(ConditionOperator.In, objectIdCondition.Operator);
+        Assert.Equal(new[] { componentId }, GetQueriedObjectIds(activeQuery));
+    }
+
+    [Fact]
+    public async Task GetSolutionComponentLayersAsync_ActiveSolutionQuery_ChunksLargeCandidateListsIntoMultipleQueries()
+    {
+        const int batchSize = 500;
+        var componentIds = Enumerable.Range(0, batchSize + 1).Select(_ => Guid.NewGuid()).ToList();
+
+        SetupPipeline(
+            "TestSolution",
+            componentIds.Select(id => MakeComponentEntity(id, SimpleComponentTypeCode)).ToList(),
+            qe => new EntityCollection(GetQueriedObjectIds(qe).Select(MakeActiveIdEntity).ToList()));
+
+        await _client.GetSolutionComponentLayersAsync("TestSolution");
+
+        // 501 candidates at a 500-per-query cap must split into two Active-solution lookups,
+        // each scoped to its own chunk — never one query covering everything at once.
+        Assert.Equal(2, _capturedActiveQueries.Count);
+        var chunkSizes = _capturedActiveQueries.Select(q => GetQueriedObjectIds(q).Count).OrderByDescending(c => c).ToList();
+        Assert.Equal(new[] { batchSize, 1 }, chunkSizes);
+
+        var queriedInPhase2 = _capturedPhase2Requests.Select(GetComponentId).ToHashSet();
+        Assert.Equal(componentIds.Count, queriedInPhase2.Count);
+        Assert.All(componentIds, id => Assert.Contains(id, queriedInPhase2));
     }
 
     [Fact]

--- a/tests/PowerApps.CLI.Tests/Infrastructure/DataverseClientSolutionLayerTests.cs
+++ b/tests/PowerApps.CLI.Tests/Infrastructure/DataverseClientSolutionLayerTests.cs
@@ -1,0 +1,228 @@
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
+using Moq;
+using PowerApps.CLI.Infrastructure;
+using Xunit;
+
+namespace PowerApps.CLI.Tests.Infrastructure;
+
+public class DataverseClientSolutionLayerTests
+{
+    // Component type code that requires no attribute/form/view/chart expansion (Phase 1b/1c),
+    // keeping these tests focused on the Phase 1d Active-solution filter and Phase 2 ColumnSet.
+    private const int SimpleComponentTypeCode = 29; // "Workflow" in the static type-name map.
+
+    private readonly Mock<IOrganizationService> _mockOrgService;
+    private readonly DataverseClient _client;
+
+    private readonly List<QueryExpression> _capturedActiveQueries = new();
+    private readonly List<(int PageNumber, string? PagingCookie)> _capturedActivePageInfos = new();
+    private readonly List<RetrieveMultipleRequest> _capturedPhase2Requests = new();
+
+    public DataverseClientSolutionLayerTests()
+    {
+        _mockOrgService = new Mock<IOrganizationService>();
+        _client = new DataverseClient(_mockOrgService.Object);
+    }
+
+    private static Entity MakeComponentEntity(Guid objectId, int typeCode)
+    {
+        var entity = new Entity("solutioncomponent");
+        entity["objectid"] = objectId;
+        entity["componenttype"] = new OptionSetValue(typeCode);
+        return entity;
+    }
+
+    private static Entity MakeActiveIdEntity(Guid objectId)
+    {
+        var entity = new Entity("solutioncomponent");
+        entity["objectid"] = objectId;
+        return entity;
+    }
+
+    private static string GetLinkedSolutionUniqueName(QueryExpression query)
+    {
+        var link = query.LinkEntities.Single();
+        var condition = link.LinkCriteria.Conditions.Single(c => c.AttributeName == "uniquename");
+        return (string)condition.Values[0];
+    }
+
+    /// <summary>
+    /// Wires up RetrieveMultiple to dispatch based on query shape: Phase 1's solutioncomponent
+    /// query (joined to the target solution), Phase 1d's solutioncomponent query (joined to
+    /// "Active"), and GetModernComponentTypeNamesAsync's solutioncomponentdefinition query
+    /// (returned empty so the static type-name map is used as-is).
+    /// </summary>
+    private void SetupPipeline(
+        string solutionName,
+        IReadOnlyList<Entity> phase1Components,
+        Func<QueryExpression, EntityCollection> activeSolutionResponder)
+    {
+        _mockOrgService
+            .Setup(s => s.RetrieveMultiple(It.IsAny<QueryBase>()))
+            .Returns<QueryBase>(q =>
+            {
+                var qe = (QueryExpression)q;
+
+                if (qe.EntityName == "solutioncomponentdefinition")
+                {
+                    return new EntityCollection();
+                }
+
+                if (qe.EntityName == "solutioncomponent")
+                {
+                    var targetUniqueName = GetLinkedSolutionUniqueName(qe);
+                    if (targetUniqueName == "Active")
+                    {
+                        _capturedActiveQueries.Add(qe);
+                        // Snapshot PageInfo as primitives — the same QueryExpression instance is
+                        // mutated in place across paging calls, so capturing the reference alone
+                        // would only ever reflect its final state.
+                        _capturedActivePageInfos.Add((qe.PageInfo.PageNumber, qe.PageInfo.PagingCookie));
+                        return activeSolutionResponder(qe);
+                    }
+
+                    Assert.Equal(solutionName, targetUniqueName);
+                    return new EntityCollection(phase1Components.ToList());
+                }
+
+                return new EntityCollection();
+            });
+
+        _mockOrgService
+            .Setup(s => s.Execute(It.IsAny<OrganizationRequest>()))
+            .Returns<OrganizationRequest>(req =>
+            {
+                var multipleRequest = (ExecuteMultipleRequest)req;
+                foreach (var inner in multipleRequest.Requests)
+                {
+                    _capturedPhase2Requests.Add((RetrieveMultipleRequest)inner);
+                }
+
+                var response = new ExecuteMultipleResponse();
+                response.Results["Responses"] = new ExecuteMultipleResponseItemCollection();
+                response.Results["IsFaulted"] = false;
+                return response;
+            });
+    }
+
+    private static Guid GetComponentId(RetrieveMultipleRequest request)
+    {
+        var query = (QueryExpression)request.Query;
+        var condition = query.Criteria.Conditions.Single(c => c.AttributeName == "msdyn_componentid");
+        return (Guid)condition.Values[0];
+    }
+
+    [Fact]
+    public async Task GetSolutionComponentLayersAsync_ActiveSolutionQuery_TargetsCorrectEntityLinkAndColumn()
+    {
+        var componentId = Guid.NewGuid();
+        SetupPipeline(
+            "TestSolution",
+            new[] { MakeComponentEntity(componentId, SimpleComponentTypeCode) },
+            _ => new EntityCollection(new List<Entity> { MakeActiveIdEntity(componentId) }));
+
+        await _client.GetSolutionComponentLayersAsync("TestSolution");
+
+        var activeQuery = Assert.Single(_capturedActiveQueries);
+        Assert.Equal("solutioncomponent", activeQuery.EntityName);
+        Assert.Equal(new[] { "objectid" }, activeQuery.ColumnSet.Columns);
+
+        var link = Assert.Single(activeQuery.LinkEntities);
+        Assert.Equal("solution", link.LinkToEntityName);
+        var condition = Assert.Single(link.LinkCriteria.Conditions);
+        Assert.Equal("uniquename", condition.AttributeName);
+        Assert.Equal(ConditionOperator.Equal, condition.Operator);
+        Assert.Equal("Active", condition.Values[0]);
+    }
+
+    [Fact]
+    public async Task GetSolutionComponentLayersAsync_ActiveSolutionQuery_PagesWhenMoreRecordsIsTrue()
+    {
+        var idOnPage1 = Guid.NewGuid();
+        var idOnPage2 = Guid.NewGuid();
+        var callCount = 0;
+
+        SetupPipeline(
+            "TestSolution",
+            new[]
+            {
+                MakeComponentEntity(idOnPage1, SimpleComponentTypeCode),
+                MakeComponentEntity(idOnPage2, SimpleComponentTypeCode)
+            },
+            _ =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    return new EntityCollection(new List<Entity> { MakeActiveIdEntity(idOnPage1) })
+                    {
+                        MoreRecords = true,
+                        PagingCookie = "cookie-page-1"
+                    };
+                }
+
+                return new EntityCollection(new List<Entity> { MakeActiveIdEntity(idOnPage2) })
+                {
+                    MoreRecords = false
+                };
+            });
+
+        await _client.GetSolutionComponentLayersAsync("TestSolution");
+
+        Assert.Equal(2, callCount);
+        Assert.Equal(2, _capturedActivePageInfos.Count);
+        Assert.Equal(1, _capturedActivePageInfos[0].PageNumber);
+        Assert.Null(_capturedActivePageInfos[0].PagingCookie);
+        Assert.Equal(2, _capturedActivePageInfos[1].PageNumber);
+        Assert.Equal("cookie-page-1", _capturedActivePageInfos[1].PagingCookie);
+
+        // Both pages' IDs should have made it into the Active set, so both components
+        // are queried in Phase 2.
+        var queriedIds = _capturedPhase2Requests.Select(GetComponentId).ToList();
+        Assert.Contains(idOnPage1, queriedIds);
+        Assert.Contains(idOnPage2, queriedIds);
+    }
+
+    [Fact]
+    public async Task GetSolutionComponentLayersAsync_ComponentNotInActiveSolution_IsExcludedFromPhase2()
+    {
+        var activeComponentId = Guid.NewGuid();
+        var inactiveComponentId = Guid.NewGuid();
+
+        SetupPipeline(
+            "TestSolution",
+            new[]
+            {
+                MakeComponentEntity(activeComponentId, SimpleComponentTypeCode),
+                MakeComponentEntity(inactiveComponentId, SimpleComponentTypeCode)
+            },
+            _ => new EntityCollection(new List<Entity> { MakeActiveIdEntity(activeComponentId) }));
+
+        await _client.GetSolutionComponentLayersAsync("TestSolution");
+
+        var queriedIds = _capturedPhase2Requests.Select(GetComponentId).ToList();
+        Assert.Contains(activeComponentId, queriedIds);
+        Assert.DoesNotContain(inactiveComponentId, queriedIds);
+    }
+
+    [Fact]
+    public async Task GetSolutionComponentLayersAsync_Phase2Query_UsesExplicitColumnSetNotAllColumns()
+    {
+        var componentId = Guid.NewGuid();
+        SetupPipeline(
+            "TestSolution",
+            new[] { MakeComponentEntity(componentId, SimpleComponentTypeCode) },
+            _ => new EntityCollection(new List<Entity> { MakeActiveIdEntity(componentId) }));
+
+        await _client.GetSolutionComponentLayersAsync("TestSolution");
+
+        var request = Assert.Single(_capturedPhase2Requests);
+        var query = (QueryExpression)request.Query;
+
+        Assert.False(query.ColumnSet.AllColumns);
+        var expectedColumns = new[] { "msdyn_componentid", "msdyn_order", "msdyn_solutionname", "msdyn_name", "msdyn_solutioncomponentname" };
+        Assert.Equal(expectedColumns.OrderBy(c => c), query.ColumnSet.Columns.OrderBy(c => c));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a Phase 1d step to `GetSolutionComponentLayersAsync` that cross-references the expanded component list against `solutioncomponent` rows belonging to the Active solution, so Phase 2 only queries `msdyn_componentlayer` for components that could possibly have an unmanaged layer (#90)
- Replaces `ColumnSet(true)` on the Phase 2 `msdyn_componentlayer` query with the 5 explicit columns `SolutionLayerService` actually reads (#91), bundled in since it touches the same query
- #92 (batch size/concurrency tuning) is deliberately left open — that issue says to revisit only if #90 leaves Phase 2 with hundreds of candidates in a real org, which we can't know until this ships

## Test plan
- [x] `dotnet build` — clean
- [x] `dotnet test` — full suite passes (404/404), including 4 new tests in `DataverseClientSolutionLayerTests.cs` covering the Active-solution query shape, paging, component inclusion/exclusion, and the explicit `ColumnSet`
- [ ] Reviewer: verify Phase 1d query/filter logic and test coverage

Closes #90, #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)