### PR TITLE
fix: deduplicate constants-generate class names for same-named tables and option sets

### DIFF
--- a/src/PowerApps.CLI/Commands/ConstantsCommand.cs
+++ b/src/PowerApps.CLI/Commands/ConstantsCommand.cs
@@ -279,7 +279,7 @@ public class ConstantsCommand
             var identifierFormatter = new IdentifierFormatter(pascalCase);
             var templateGenerator = new CodeTemplateGenerator(true, true, identifierFormatter);
             var constantsFilter = new ConstantsFilter();
-            var constantsGenerator = new ConstantsGenerator(templateGenerator, constantsFilter, fileWriter);
+            var constantsGenerator = new ConstantsGenerator(templateGenerator, constantsFilter, fileWriter, identifierFormatter);
 
             // Load configuration
             ConstantsConfig? config = null;

--- a/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
+++ b/src/PowerApps.CLI/Services/CodeTemplateGenerator.cs
@@ -22,10 +22,10 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
     /// <summary>
     /// Generates a complete entity class.
     /// </summary>
-    public string GenerateEntityClass(EntitySchema entity, string namespaceName)
+    public string GenerateEntityClass(EntitySchema entity, string namespaceName, string? classNameOverride = null)
     {
         var sb = new StringBuilder();
-        var className = _formatter.ToIdentifier(entity.DisplayName ?? entity.SchemaName ?? entity.LogicalName);
+        var className = classNameOverride ?? _formatter.ToIdentifier(entity.DisplayName ?? entity.SchemaName ?? entity.LogicalName);
 
         // Namespace
         sb.AppendLine($"namespace {namespaceName}");
@@ -82,12 +82,12 @@ public class CodeTemplateGenerator : ICodeTemplateGenerator
     /// <summary>
     /// Generates a global option set class.
     /// </summary>
-    public string GenerateGlobalOptionSetClass(OptionSetSchema optionSet, string namespaceName)
+    public string GenerateGlobalOptionSetClass(OptionSetSchema optionSet, string namespaceName, string? classNameOverride = null)
     {
         var sb = new StringBuilder();
-        
+
         // Use DisplayName for the class name, fall back to Name if not available
-        var className = _formatter.ToIdentifier(optionSet.DisplayName ?? optionSet.Name ?? "UnknownOptionSet");
+        var className = classNameOverride ?? _formatter.ToIdentifier(optionSet.DisplayName ?? optionSet.Name ?? "UnknownOptionSet");
 
         sb.AppendLine($"namespace {namespaceName}");
         sb.AppendLine("{");

--- a/src/PowerApps.CLI/Services/ConstantsGenerator.cs
+++ b/src/PowerApps.CLI/Services/ConstantsGenerator.cs
@@ -11,15 +11,18 @@ public class ConstantsGenerator : IConstantsGenerator
     private readonly ICodeTemplateGenerator _templateGenerator;
     private readonly IConstantsFilter _filter;
     private readonly IFileWriter _fileWriter;
+    private readonly IIdentifierFormatter _formatter;
 
     public ConstantsGenerator(
         ICodeTemplateGenerator templateGenerator,
         IConstantsFilter filter,
-        IFileWriter fileWriter)
+        IFileWriter fileWriter,
+        IIdentifierFormatter formatter)
     {
         _templateGenerator = templateGenerator;
         _filter = filter;
         _fileWriter = fileWriter;
+        _formatter = formatter;
     }
 
     /// <summary>
@@ -60,8 +63,15 @@ public class ConstantsGenerator : IConstantsGenerator
         if (outputConfig.IncludeEntities && entities.Count > 0)
         {
             logger.LogInfo($"  Generating Tables.cs with {entities.Count} entit{(entities.Count == 1 ? "y" : "ies")}...");
-            var classContents = entities.Select(e => 
-                _templateGenerator.GenerateEntityClass(e, outputConfig.Namespace));
+            var usedClassNames = new HashSet<string>();
+            var classContents = entities.Select(e =>
+            {
+                var className = _formatter.MakeUnique(
+                    _formatter.ToIdentifier(e.DisplayName ?? e.SchemaName ?? e.LogicalName),
+                    usedClassNames);
+                usedClassNames.Add(className);
+                return _templateGenerator.GenerateEntityClass(e, outputConfig.Namespace, className);
+            });
             var content = _templateGenerator.GenerateSingleFile(outputConfig.Namespace, classContents);
             await _fileWriter.WriteTextAsync(Path.Combine(outputConfig.OutputPath, "Tables.cs"), content);
         }
@@ -70,8 +80,15 @@ public class ConstantsGenerator : IConstantsGenerator
         if (outputConfig.IncludeGlobalOptionSets && globalOptionSets != null && globalOptionSets.Count > 0)
         {
             logger.LogInfo($"  Generating Choices.cs with {globalOptionSets.Count} option set(s)...");
+            var usedClassNames = new HashSet<string>();
             var classContents = globalOptionSets.Select(o =>
-                _templateGenerator.GenerateGlobalOptionSetClass(o, outputConfig.Namespace));
+            {
+                var className = _formatter.MakeUnique(
+                    _formatter.ToIdentifier(o.DisplayName ?? o.Name ?? "UnknownOptionSet"),
+                    usedClassNames);
+                usedClassNames.Add(className);
+                return _templateGenerator.GenerateGlobalOptionSetClass(o, outputConfig.Namespace, className);
+            });
             var content = _templateGenerator.GenerateSingleFile(outputConfig.Namespace, classContents);
             await _fileWriter.WriteTextAsync(Path.Combine(outputConfig.OutputPath, "Choices.cs"), content);
         }
@@ -88,13 +105,16 @@ public class ConstantsGenerator : IConstantsGenerator
         {
             logger.LogInfo($"  Generating {entities.Count} entity file(s)...");
             var entitiesPath = Path.Combine(outputConfig.OutputPath, "Tables");
-            var formatter = new IdentifierFormatter(outputConfig.PascalCaseConversion);
+            var usedClassNames = new HashSet<string>();
 
             foreach (var entity in entities)
             {
-                var className = formatter.ToIdentifier(entity.DisplayName ?? entity.SchemaName ?? entity.LogicalName);
+                var className = _formatter.MakeUnique(
+                    _formatter.ToIdentifier(entity.DisplayName ?? entity.SchemaName ?? entity.LogicalName),
+                    usedClassNames);
+                usedClassNames.Add(className);
                 var fileName = $"{className}.cs";
-                var content = _templateGenerator.GenerateEntityClass(entity, $"{outputConfig.Namespace}.Tables");
+                var content = _templateGenerator.GenerateEntityClass(entity, $"{outputConfig.Namespace}.Tables", className);
                 await _fileWriter.WriteTextAsync(Path.Combine(entitiesPath, fileName), content);
             }
         }
@@ -104,13 +124,16 @@ public class ConstantsGenerator : IConstantsGenerator
         {
             logger.LogInfo($"  Generating {globalOptionSets.Count} option set file(s)...");
             var optionSetsPath = Path.Combine(outputConfig.OutputPath, "Choices");
-            var formatter = new IdentifierFormatter(outputConfig.PascalCaseConversion);
+            var usedClassNames = new HashSet<string>();
 
             foreach (var optionSet in globalOptionSets)
             {
-                var className = formatter.ToIdentifier(optionSet.DisplayName ?? optionSet.Name ?? "UnknownOptionSet");
+                var className = _formatter.MakeUnique(
+                    _formatter.ToIdentifier(optionSet.DisplayName ?? optionSet.Name ?? "UnknownOptionSet"),
+                    usedClassNames);
+                usedClassNames.Add(className);
                 var fileName = $"{className}.cs";
-                var content = _templateGenerator.GenerateGlobalOptionSetClass(optionSet, $"{outputConfig.Namespace}.Choices");
+                var content = _templateGenerator.GenerateGlobalOptionSetClass(optionSet, $"{outputConfig.Namespace}.Choices", className);
                 await _fileWriter.WriteTextAsync(Path.Combine(optionSetsPath, fileName), content);
             }
         }

--- a/src/PowerApps.CLI/Services/ConstantsGenerator.cs
+++ b/src/PowerApps.CLI/Services/ConstantsGenerator.cs
@@ -35,11 +35,18 @@ public class ConstantsGenerator : IConstantsGenerator
     {
         logger.LogInfo($"Generating constants to: {outputConfig.OutputPath}");
 
+        // Sort into a deterministic order before any dedup naming below runs — Dataverse metadata
+        // query ordering is not guaranteed stable, so leaving this unsorted would let MakeUnique
+        // assign e.g. "Email" vs "Email_" differently between otherwise-identical runs.
+        entities = entities.OrderBy(e => e.LogicalName, StringComparer.OrdinalIgnoreCase).ToList();
+
         // Extract global option sets if needed
         List<OptionSetSchema>? globalOptionSets = null;
         if (outputConfig.IncludeGlobalOptionSets)
         {
-            globalOptionSets = _filter.ExtractGlobalOptionSets(entities);
+            globalOptionSets = _filter.ExtractGlobalOptionSets(entities)
+                .OrderBy(o => o.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
             logger.LogInfo($"  Found {globalOptionSets.Count} global option set(s)");
         }
 

--- a/src/PowerApps.CLI/Services/ICodeTemplateGenerator.cs
+++ b/src/PowerApps.CLI/Services/ICodeTemplateGenerator.cs
@@ -8,14 +8,18 @@ namespace PowerApps.CLI.Services;
 public interface ICodeTemplateGenerator
 {
     /// <summary>
-    /// Generates a complete entity class.
+    /// Generates a complete entity class. If <paramref name="classNameOverride"/> is supplied, it is
+    /// used instead of computing the class name from the entity's display name — used by callers that
+    /// need to deduplicate class names across multiple entities being generated together.
     /// </summary>
-    string GenerateEntityClass(EntitySchema entity, string namespaceName);
+    string GenerateEntityClass(EntitySchema entity, string namespaceName, string? classNameOverride = null);
 
     /// <summary>
-    /// Generates a global option set class.
+    /// Generates a global option set class. If <paramref name="classNameOverride"/> is supplied, it is
+    /// used instead of computing the class name from the option set's display name — used by callers that
+    /// need to deduplicate class names across multiple option sets being generated together.
     /// </summary>
-    string GenerateGlobalOptionSetClass(OptionSetSchema optionSet, string namespaceName);
+    string GenerateGlobalOptionSetClass(OptionSetSchema optionSet, string namespaceName, string? classNameOverride = null);
 
     /// <summary>
     /// Combines multiple classes into a single file.

--- a/tests/PowerApps.CLI.IntegrationTests/Infrastructure/DataverseFixture.cs
+++ b/tests/PowerApps.CLI.IntegrationTests/Infrastructure/DataverseFixture.cs
@@ -88,10 +88,12 @@ public class DataverseFixture : IDisposable
             ExcludeAttributes = config.ExcludeAttributes
         };
 
+        var identifierFormatter = new IdentifierFormatter(config.PascalCaseConversion);
         var generator = new ConstantsGenerator(
-            new CodeTemplateGenerator(true, true, new IdentifierFormatter(config.PascalCaseConversion)),
+            new CodeTemplateGenerator(true, true, identifierFormatter),
             filter,
-            new FileWriter());
+            new FileWriter(),
+            identifierFormatter);
 
         await generator.GenerateAsync(entities, outputConfig, new ConsoleLogger());
 

--- a/tests/PowerApps.CLI.Tests/Services/ConstantsGeneratorTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/ConstantsGeneratorTests.cs
@@ -459,4 +459,48 @@ public class ConstantsGeneratorTests
         Assert.Contains("public static class Email", writtenFiles[0].Content);
         Assert.Contains("public static class Email_", writtenFiles[1].Content);
     }
+
+    [Fact]
+    public async Task GenerateAsync_SingleFileMode_DuplicateNames_OutputIsDeterministicRegardlessOfInputOrderAsync()
+    {
+        // Arrange — Dataverse metadata query ordering isn't guaranteed stable between runs, so feed
+        // the same two same-named entities in reverse order and confirm the dedup naming (Email vs
+        // Email_) doesn't flip depending on that incidental ordering.
+        async Task<string> GenerateAsync(List<EntitySchema> entities)
+        {
+            var mockFilter = new Mock<IConstantsFilter>();
+            var mockFileWriter = new Mock<IFileWriter>();
+            var mockLogger = new Mock<IConsoleLogger>();
+            var templateGenerator = new CodeTemplateGenerator(true, true, new IdentifierFormatter());
+
+            string? capturedContent = null;
+            mockFileWriter
+                .Setup(x => x.WriteTextAsync(It.Is<string>(p => p.EndsWith("Tables.cs")), It.IsAny<string>()))
+                .Callback<string, string>((_, content) => capturedContent = content)
+                .Returns(Task.CompletedTask);
+
+            var generator = new ConstantsGenerator(templateGenerator, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+            var outputConfig = new ConstantsOutputConfig
+            {
+                OutputPath = "./output",
+                Namespace = "MyCompany.Constants",
+                SingleFile = true,
+                IncludeEntities = true,
+                IncludeGlobalOptionSets = false
+            };
+
+            await generator.GenerateAsync(entities, outputConfig, mockLogger.Object);
+            return capturedContent!;
+        }
+
+        var entityA = new EntitySchema { LogicalName = "rob_email", DisplayName = "Email" };
+        var entityB = new EntitySchema { LogicalName = "email", DisplayName = "Email" };
+
+        // Act
+        var forwardOrder = await GenerateAsync(new List<EntitySchema> { entityA, entityB });
+        var reverseOrder = await GenerateAsync(new List<EntitySchema> { entityB, entityA });
+
+        // Assert
+        Assert.Equal(forwardOrder, reverseOrder);
+    }
 }

--- a/tests/PowerApps.CLI.Tests/Services/ConstantsGeneratorTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/ConstantsGeneratorTests.cs
@@ -18,14 +18,14 @@ public class ConstantsGeneratorTests
         var mockLogger = new Mock<IConsoleLogger>();
 
         mockTemplateGenerator
-            .Setup(x => x.GenerateEntityClass(It.IsAny<EntitySchema>(), It.IsAny<string>()))
+            .Setup(x => x.GenerateEntityClass(It.IsAny<EntitySchema>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns("class content");
         mockTemplateGenerator
             .Setup(x => x.GenerateSingleFile(It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
             .Returns("combined content");
 
-        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object);
-        
+        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
         var entities = new List<EntitySchema>
         {
             new EntitySchema { LogicalName = "contact" }
@@ -66,14 +66,14 @@ public class ConstantsGeneratorTests
             .Setup(x => x.ExtractGlobalOptionSets(It.IsAny<List<EntitySchema>>()))
             .Returns(globalOptionSets);
         mockTemplateGenerator
-            .Setup(x => x.GenerateGlobalOptionSetClass(It.IsAny<OptionSetSchema>(), It.IsAny<string>()))
+            .Setup(x => x.GenerateGlobalOptionSetClass(It.IsAny<OptionSetSchema>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns("optionset content");
         mockTemplateGenerator
             .Setup(x => x.GenerateSingleFile(It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
             .Returns("combined optionsets");
 
-        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object);
-        
+        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
         var entities = new List<EntitySchema> { new EntitySchema { LogicalName = "contact" } };
         var outputConfig = new ConstantsOutputConfig
         {
@@ -103,11 +103,11 @@ public class ConstantsGeneratorTests
         var mockLogger = new Mock<IConsoleLogger>();
 
         mockTemplateGenerator
-            .Setup(x => x.GenerateEntityClass(It.IsAny<EntitySchema>(), It.IsAny<string>()))
+            .Setup(x => x.GenerateEntityClass(It.IsAny<EntitySchema>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns("entity class content");
 
-        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object);
-        
+        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
         var entities = new List<EntitySchema>
         {
             new EntitySchema { LogicalName = "contact", DisplayName = "Contact" },
@@ -153,11 +153,11 @@ public class ConstantsGeneratorTests
             .Setup(x => x.ExtractGlobalOptionSets(It.IsAny<List<EntitySchema>>()))
             .Returns(globalOptionSets);
         mockTemplateGenerator
-            .Setup(x => x.GenerateGlobalOptionSetClass(It.IsAny<OptionSetSchema>(), It.IsAny<string>()))
+            .Setup(x => x.GenerateGlobalOptionSetClass(It.IsAny<OptionSetSchema>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns("optionset class content");
 
-        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object);
-        
+        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
         var entities = new List<EntitySchema> { new EntitySchema { LogicalName = "contact" } };
         var outputConfig = new ConstantsOutputConfig
         {
@@ -189,8 +189,8 @@ public class ConstantsGeneratorTests
         var mockFileWriter = new Mock<IFileWriter>();
         var mockLogger = new Mock<IConsoleLogger>();
 
-        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object);
-        
+        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
         var entities = new List<EntitySchema>
         {
             new EntitySchema { LogicalName = "contact" }
@@ -223,14 +223,14 @@ public class ConstantsGeneratorTests
         var mockLogger = new Mock<IConsoleLogger>();
 
         mockTemplateGenerator
-            .Setup(x => x.GenerateEntityClass(It.IsAny<EntitySchema>(), It.IsAny<string>()))
+            .Setup(x => x.GenerateEntityClass(It.IsAny<EntitySchema>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns("content");
         mockTemplateGenerator
             .Setup(x => x.GenerateSingleFile(It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
             .Returns("combined");
 
-        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object);
-        
+        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
         var entities = new List<EntitySchema>
         {
             new EntitySchema { LogicalName = "contact" },
@@ -263,11 +263,11 @@ public class ConstantsGeneratorTests
         var mockLogger = new Mock<IConsoleLogger>();
 
         mockTemplateGenerator
-            .Setup(x => x.GenerateEntityClass(It.IsAny<EntitySchema>(), It.IsAny<string>()))
+            .Setup(x => x.GenerateEntityClass(It.IsAny<EntitySchema>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns("content");
 
-        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object);
-        
+        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
         var entities = new List<EntitySchema>
         {
             new EntitySchema { LogicalName = "contact", DisplayName = "Contact" }
@@ -287,7 +287,8 @@ public class ConstantsGeneratorTests
         // Assert
         mockTemplateGenerator.Verify(x => x.GenerateEntityClass(
             It.IsAny<EntitySchema>(),
-            "MyCompany.Constants.Tables"), Times.Once);
+            "MyCompany.Constants.Tables",
+            "Contact"), Times.Once);
     }
 
     [Fact]
@@ -308,11 +309,11 @@ public class ConstantsGeneratorTests
             .Setup(x => x.ExtractGlobalOptionSets(It.IsAny<List<EntitySchema>>()))
             .Returns(globalOptionSets);
         mockTemplateGenerator
-            .Setup(x => x.GenerateGlobalOptionSetClass(It.IsAny<OptionSetSchema>(), It.IsAny<string>()))
+            .Setup(x => x.GenerateGlobalOptionSetClass(It.IsAny<OptionSetSchema>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns("content");
 
-        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object);
-        
+        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
         var entities = new List<EntitySchema> { new EntitySchema { LogicalName = "contact" } };
         var outputConfig = new ConstantsOutputConfig
         {
@@ -329,6 +330,133 @@ public class ConstantsGeneratorTests
         // Assert
         mockTemplateGenerator.Verify(x => x.GenerateGlobalOptionSetClass(
             It.IsAny<OptionSetSchema>(),
-            "MyCompany.Constants.Choices"), Times.Once);
+            "MyCompany.Constants.Choices",
+            "Statuscode"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_SingleFileMode_TwoTablesWithSameDisplayName_DeduplicatesClassNamesAsync()
+    {
+        // Arrange
+        var mockFilter = new Mock<IConstantsFilter>();
+        var mockFileWriter = new Mock<IFileWriter>();
+        var mockLogger = new Mock<IConsoleLogger>();
+        var templateGenerator = new CodeTemplateGenerator(true, true, new IdentifierFormatter());
+
+        string? capturedContent = null;
+        mockFileWriter
+            .Setup(x => x.WriteTextAsync(It.Is<string>(p => p.EndsWith("Tables.cs")), It.IsAny<string>()))
+            .Callback<string, string>((_, content) => capturedContent = content)
+            .Returns(Task.CompletedTask);
+
+        var generator = new ConstantsGenerator(templateGenerator, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
+        var entities = new List<EntitySchema>
+        {
+            new EntitySchema { LogicalName = "rob_email", DisplayName = "Email" },
+            new EntitySchema { LogicalName = "email", DisplayName = "Email" }
+        };
+        var outputConfig = new ConstantsOutputConfig
+        {
+            OutputPath = "./output",
+            Namespace = "MyCompany.Constants",
+            SingleFile = true,
+            IncludeEntities = true,
+            IncludeGlobalOptionSets = false
+        };
+
+        // Act
+        await generator.GenerateAsync(entities, outputConfig, mockLogger.Object);
+
+        // Assert
+        Assert.NotNull(capturedContent);
+        Assert.Contains("public static class Email", capturedContent);
+        Assert.Contains("public static class Email_", capturedContent);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_SingleFileMode_TwoGlobalOptionSetsWithSameDisplayName_DeduplicatesClassNamesAsync()
+    {
+        // Arrange
+        var mockFilter = new Mock<IConstantsFilter>();
+        var mockFileWriter = new Mock<IFileWriter>();
+        var mockLogger = new Mock<IConsoleLogger>();
+        var templateGenerator = new CodeTemplateGenerator(true, true, new IdentifierFormatter());
+
+        var globalOptionSets = new List<OptionSetSchema>
+        {
+            new OptionSetSchema { Name = "rob_priority", DisplayName = "Priority", IsGlobal = true },
+            new OptionSetSchema { Name = "xrt_priority", DisplayName = "Priority", IsGlobal = true }
+        };
+        mockFilter
+            .Setup(x => x.ExtractGlobalOptionSets(It.IsAny<List<EntitySchema>>()))
+            .Returns(globalOptionSets);
+
+        string? capturedContent = null;
+        mockFileWriter
+            .Setup(x => x.WriteTextAsync(It.Is<string>(p => p.EndsWith("Choices.cs")), It.IsAny<string>()))
+            .Callback<string, string>((_, content) => capturedContent = content)
+            .Returns(Task.CompletedTask);
+
+        var generator = new ConstantsGenerator(templateGenerator, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
+        var entities = new List<EntitySchema> { new EntitySchema { LogicalName = "contact" } };
+        var outputConfig = new ConstantsOutputConfig
+        {
+            OutputPath = "./output",
+            Namespace = "MyCompany.Constants",
+            SingleFile = true,
+            IncludeEntities = false,
+            IncludeGlobalOptionSets = true
+        };
+
+        // Act
+        await generator.GenerateAsync(entities, outputConfig, mockLogger.Object);
+
+        // Assert
+        Assert.NotNull(capturedContent);
+        Assert.Contains("public static class Priority", capturedContent);
+        Assert.Contains("public static class Priority_", capturedContent);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_MultipleFilesMode_TwoTablesWithSameDisplayName_DeduplicatesFileAndClassNamesAsync()
+    {
+        // Arrange
+        var mockFilter = new Mock<IConstantsFilter>();
+        var mockFileWriter = new Mock<IFileWriter>();
+        var mockLogger = new Mock<IConsoleLogger>();
+        var templateGenerator = new CodeTemplateGenerator(true, true, new IdentifierFormatter());
+
+        var writtenFiles = new List<(string Path, string Content)>();
+        mockFileWriter
+            .Setup(x => x.WriteTextAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string>((path, content) => writtenFiles.Add((path, content)))
+            .Returns(Task.CompletedTask);
+
+        var generator = new ConstantsGenerator(templateGenerator, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
+        var entities = new List<EntitySchema>
+        {
+            new EntitySchema { LogicalName = "rob_email", DisplayName = "Email" },
+            new EntitySchema { LogicalName = "email", DisplayName = "Email" }
+        };
+        var outputConfig = new ConstantsOutputConfig
+        {
+            OutputPath = "./output",
+            Namespace = "MyCompany.Constants",
+            SingleFile = false,
+            IncludeEntities = true,
+            IncludeGlobalOptionSets = false
+        };
+
+        // Act
+        await generator.GenerateAsync(entities, outputConfig, mockLogger.Object);
+
+        // Assert — two distinct files, not a silent overwrite, each with a distinct class name
+        Assert.Equal(2, writtenFiles.Count);
+        Assert.NotEqual(writtenFiles[0].Path, writtenFiles[1].Path);
+        Assert.Contains("public static class Email", writtenFiles[0].Content);
+        Assert.Contains("public static class Email_", writtenFiles[1].Content);
     }
 }


### PR DESCRIPTION
## Summary
- Tables and global option sets that share a display name (e.g. two `Email` tables from different publishers) produced two identically-named C# classes in the same namespace, which fails to compile (CS0101).
- Applies the existing `MakeUnique` dedup pattern (already used for attribute/option names within a class) across the full set of entities/option sets in a generation run.
- Fixes both single-file mode (`Tables.cs` / `Choices.cs`) and multiple-files mode — the latter also stopped silently overwriting one file with the other when class names collided, since file names are derived from the same name.
- Sorts entities (by `LogicalName`) and global option sets (by `Name`) before the dedup pass runs, so which duplicate gets the plain name vs the `_`-suffixed name doesn't depend on unstable Dataverse metadata query ordering.

## Changes
- `ICodeTemplateGenerator` / `CodeTemplateGenerator`: `GenerateEntityClass` / `GenerateGlobalOptionSetClass` accept an optional `classNameOverride`.
- `ConstantsGenerator`: now takes `IIdentifierFormatter` via DI and dedupes class names per run, in both modes, over a sorted, deterministic input order.
- `ConstantsCommand`: wiring updated to share the same `identifierFormatter` instance between `CodeTemplateGenerator` and `ConstantsGenerator`, so file name and class name can never disagree with each other.
- `DataverseFixture.cs` (integration tests): updated call site for the new constructor param.
- `ConstantsGeneratorTests.cs`: updated existing mocks for the new signature, plus tests covering the collision scenarios for both modes and a determinism regression test (same input in reverse order produces identical output).

Fixes #94

## Known follow-up (not fixed here)

Sharing one `identifierFormatter` instance (previous point) is necessary so dedup naming can't disagree between file name and class content, but it surfaces a separate, pre-existing bug rather than fixing anything: that formatter is built in `ConstantsCommand.CreateCliCommand()` from the `--pascal-case` CLI flag *before* a `--config` file is loaded, so a config file's `PascalCaseConversion` setting is silently ignored for naming. This already affected single-file mode; before this PR, multi-file mode's *file names* happened to read the correct post-config-load value (via a local, now-removed formatter), even though the *class name inside that file* already didn't — an internal mismatch, arguably a worse bug. This PR removes that mismatch by making both consistently use the DI-time formatter, which means multi-file mode now also ignores `--config`'s `PascalCaseConversion` for naming, same as single-file mode always has. Filed as #96 rather than folded in here, since the real fix (reordering construction in `ConstantsCommand`) is a separate concern from deduping class names.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — 404/404 passing, including dedup tests for single-file (tables + option sets) and multi-file (tables) collision scenarios, plus an order-independence determinism test