### PR TITLE
fix: wire up IncludeComments/IncludeRelationships and add matching CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,8 @@ Generates C# constants from Dataverse metadata.
 | `--attribute-prefix` | Only include attributes with this prefix | No | - |
 | `--pascal-case` | Convert identifiers to PascalCase | No | `true` |
 | `--skip-virtual-fields` | Exclude virtual fields from generated constants | No | `false` |
+| `--include-comments` | Include XML doc comments on generated constants | No | `true` |
+| `--include-relationships` | Include relationship metadata in generated constants | No | `true` |
 
 \* Either `--url` or `--connection-string` must be provided.
 

--- a/src/PowerApps.CLI/Commands/ConstantsCommand.cs
+++ b/src/PowerApps.CLI/Commands/ConstantsCommand.cs
@@ -233,6 +233,16 @@ public class ConstantsCommand
             getDefaultValue: () => false,
             description: "Exclude virtual fields from generated constants — skips lookup companion fields (AttributeOf is set, e.g. createdbyname) and Virtual-type attributes (e.g. EntityImage_URL)");
 
+        var includeCommentsOption = new Option<bool>(
+            aliases: new[] { "--include-comments" },
+            getDefaultValue: () => true,
+            description: "Include XML doc comments on generated constants");
+
+        var includeRelationshipsOption = new Option<bool>(
+            aliases: new[] { "--include-relationships" },
+            getDefaultValue: () => true,
+            description: "Include relationship metadata in generated constants");
+
         constantsGenerateCommand.AddOption(urlOption);
         constantsGenerateCommand.AddOption(solutionOption);
         constantsGenerateCommand.AddOption(outputOption);
@@ -250,6 +260,8 @@ public class ConstantsCommand
         constantsGenerateCommand.AddOption(attributePrefixOption);
         constantsGenerateCommand.AddOption(pascalCaseOption);
         constantsGenerateCommand.AddOption(skipVirtualFieldsOption);
+        constantsGenerateCommand.AddOption(includeCommentsOption);
+        constantsGenerateCommand.AddOption(includeRelationshipsOption);
 
         constantsGenerateCommand.SetHandler(async (context) =>
         {
@@ -270,6 +282,8 @@ public class ConstantsCommand
             var attributePrefix = context.ParseResult.GetValueForOption(attributePrefixOption);
             var pascalCase = context.ParseResult.GetValueForOption(pascalCaseOption);
             var skipVirtualFields = context.ParseResult.GetValueForOption(skipVirtualFieldsOption);
+            var includeComments = context.ParseResult.GetValueForOption(includeCommentsOption);
+            var includeRelationships = context.ParseResult.GetValueForOption(includeRelationshipsOption);
 
             var logger = new ConsoleLogger { IsVerboseEnabled = verbose };
 
@@ -291,7 +305,10 @@ public class ConstantsCommand
             var fileWriter = new FileWriter();
             var metadataMapper = new MetadataMapper();
             var identifierFormatter = new IdentifierFormatter(ResolvePascalCaseConversion(config, pascalCase));
-            var templateGenerator = new CodeTemplateGenerator(true, true, identifierFormatter);
+            var templateGenerator = new CodeTemplateGenerator(
+                ResolveIncludeComments(config, includeComments),
+                ResolveIncludeRelationships(config, includeRelationships),
+                identifierFormatter);
             var constantsFilter = new ConstantsFilter();
             var constantsGenerator = new ConstantsGenerator(templateGenerator, constantsFilter, fileWriter, identifierFormatter);
 
@@ -320,6 +337,24 @@ public class ConstantsCommand
     internal static bool ResolvePascalCaseConversion(ConstantsConfig? config, bool cliPascalCaseFlag)
     {
         return config?.PascalCaseConversion ?? cliPascalCaseFlag;
+    }
+
+    /// <summary>
+    /// Resolves the effective IncludeComments setting: a loaded config file takes precedence over the
+    /// --include-comments CLI flag.
+    /// </summary>
+    internal static bool ResolveIncludeComments(ConstantsConfig? config, bool cliIncludeCommentsFlag)
+    {
+        return config?.IncludeComments ?? cliIncludeCommentsFlag;
+    }
+
+    /// <summary>
+    /// Resolves the effective IncludeRelationships setting: a loaded config file takes precedence over
+    /// the --include-relationships CLI flag.
+    /// </summary>
+    internal static bool ResolveIncludeRelationships(ConstantsConfig? config, bool cliIncludeRelationshipsFlag)
+    {
+        return config?.IncludeRelationships ?? cliIncludeRelationshipsFlag;
     }
 
     private static async Task<ConstantsConfig?> LoadConfigAsync(string configPath, IConsoleLogger logger)

--- a/tests/PowerApps.CLI.Tests/Commands/ConstantsCommandTests.cs
+++ b/tests/PowerApps.CLI.Tests/Commands/ConstantsCommandTests.cs
@@ -239,4 +239,38 @@ public class ConstantsCommandTests
 
         Assert.Equal(expected, result);
     }
+
+    [Theory]
+    [InlineData(null, true, true)]
+    [InlineData(null, false, false)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, false)]
+    public void ResolveIncludeComments_ConfigTakesPrecedenceOverCliFlag(
+        bool? configIncludeComments, bool cliIncludeCommentsFlag, bool expected)
+    {
+        var config = configIncludeComments.HasValue
+            ? new ConstantsConfig { IncludeComments = configIncludeComments.Value }
+            : null;
+
+        var result = ConstantsCommand.ResolveIncludeComments(config, cliIncludeCommentsFlag);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, true, true)]
+    [InlineData(null, false, false)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, false)]
+    public void ResolveIncludeRelationships_ConfigTakesPrecedenceOverCliFlag(
+        bool? configIncludeRelationships, bool cliIncludeRelationshipsFlag, bool expected)
+    {
+        var config = configIncludeRelationships.HasValue
+            ? new ConstantsConfig { IncludeRelationships = configIncludeRelationships.Value }
+            : null;
+
+        var result = ConstantsCommand.ResolveIncludeRelationships(config, cliIncludeRelationshipsFlag);
+
+        Assert.Equal(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- `ConstantsCommand.CreateCliCommand()` always built `CodeTemplateGenerator` with hardcoded `(true, true)` for `includeComments`/`includeRelationships`, so `ConstantsConfig.IncludeComments`/`IncludeRelationships` had no effect via `--config`, and there was no CLI flag for either at all.
- Added `--include-comments` / `--include-relationships` CLI flags (default `true`, matching the existing `ConstantsConfig` defaults), for parity with the other include/exclude options.
- Resolves the effective value the same way #98 already fixed for `--pascal-case`: config file takes precedence over the CLI flag when both are present (`ResolveIncludeComments` / `ResolveIncludeRelationships`, same pattern as `ResolvePascalCaseConversion`).
- Updated README's `constants-generate` options table with the two new flags.

Fixes #97

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — 416/416 passing, including new `[Theory]` tests for both resolve helpers
- [x] `dotnet run -- constants-generate --help` shows both new flags with correct defaults