### PR TITLE
chore: remove dead ConstantsOutputConfig.PascalCaseConversion

### DIFF
--- a/src/PowerApps.CLI/Commands/ConstantsCommand.cs
+++ b/src/PowerApps.CLI/Commands/ConstantsCommand.cs
@@ -132,7 +132,6 @@ public class ConstantsCommand
                 IncludeEntities = filterConfig.IncludeEntities,
                 IncludeGlobalOptionSets = filterConfig.IncludeGlobalOptionSets,
                 IncludeReferenceData = filterConfig.IncludeReferenceData,
-                PascalCaseConversion = filterConfig.PascalCaseConversion,
                 ExcludeAttributes = filterConfig.ExcludeAttributes
             };
 

--- a/src/PowerApps.CLI/Models/ConstantsConfig.cs
+++ b/src/PowerApps.CLI/Models/ConstantsConfig.cs
@@ -37,7 +37,6 @@ public class ConstantsOutputConfig
     public bool IncludeRelationships { get; set; } = true;
     public bool IncludeReferenceData { get; set; }
     public bool IncludeComments { get; set; } = true;
-    public bool PascalCaseConversion { get; set; } = true;
     public List<string> ExcludeAttributes { get; set; } = new();
 
     public override string ToString()

--- a/tests/PowerApps.CLI.IntegrationTests/Infrastructure/DataverseFixture.cs
+++ b/tests/PowerApps.CLI.IntegrationTests/Infrastructure/DataverseFixture.cs
@@ -84,7 +84,6 @@ public class DataverseFixture : IDisposable
             SingleFile = config.SingleFile,
             IncludeEntities = config.IncludeEntities,
             IncludeGlobalOptionSets = config.IncludeGlobalOptionSets,
-            PascalCaseConversion = config.PascalCaseConversion,
             ExcludeAttributes = config.ExcludeAttributes
         };
 

--- a/tests/PowerApps.CLI.Tests/Commands/ConstantsCommandTests.cs
+++ b/tests/PowerApps.CLI.Tests/Commands/ConstantsCommandTests.cs
@@ -77,8 +77,7 @@ public class ConstantsCommandTests
             entities,
             It.Is<ConstantsOutputConfig>(c =>
                 c.OutputPath == "./Generated" &&
-                c.Namespace == "My.Namespace" &&
-                c.PascalCaseConversion == true),
+                c.Namespace == "My.Namespace"),
             _mockLogger.Object), Times.Once);
     }
 

--- a/tests/PowerApps.CLI.Tests/Models/ModelTests.cs
+++ b/tests/PowerApps.CLI.Tests/Models/ModelTests.cs
@@ -377,7 +377,6 @@ public class ModelTests
         Assert.True(config.IncludeRelationships);
         Assert.False(config.IncludeReferenceData);
         Assert.True(config.IncludeComments);
-        Assert.True(config.PascalCaseConversion);
         Assert.Empty(config.ExcludeAttributes);
     }
 }


### PR DESCRIPTION
## Summary
- `ConstantsOutputConfig.PascalCaseConversion` was still being assigned in `ConstantsCommand.ExecuteAsync` (from `filterConfig.PascalCaseConversion`) and in the integration test fixture, but nothing ever reads it — since #94/#96, casing/dedup naming is resolved entirely through the directly-injected `IIdentifierFormatter`, constructed once in `ConstantsCommand.CreateCliCommand()` via `ResolvePascalCaseConversion`.
- Removed the dead property and its two assignment sites, plus the test assertions that only existed to pin its default value.
- `ConstantsConfig.PascalCaseConversion` (the one that actually drives behavior, via `ResolvePascalCaseConversion`) is untouched.

Fixes #100

## Test plan
- [x] `dotnet build` succeeds (including integration test project)
- [x] `dotnet test` — 416/416 passing
- [x] `grep -rn "PascalCaseConversion"` confirms every remaining reference is to the live `ConstantsConfig.PascalCaseConversion`, not the removed `ConstantsOutputConfig` one