### PR TITLE
chore: remove dead ConstantsOutputConfig.IncludeComments/IncludeRelationships

### DIFF
--- a/src/PowerApps.CLI/Models/ConstantsConfig.cs
+++ b/src/PowerApps.CLI/Models/ConstantsConfig.cs
@@ -34,9 +34,7 @@ public class ConstantsOutputConfig
     public bool SingleFile { get; set; }
     public bool IncludeEntities { get; set; } = true;
     public bool IncludeGlobalOptionSets { get; set; } = true;
-    public bool IncludeRelationships { get; set; } = true;
     public bool IncludeReferenceData { get; set; }
-    public bool IncludeComments { get; set; } = true;
     public List<string> ExcludeAttributes { get; set; } = new();
 
     public override string ToString()

--- a/tests/PowerApps.CLI.Tests/Models/ModelTests.cs
+++ b/tests/PowerApps.CLI.Tests/Models/ModelTests.cs
@@ -374,9 +374,7 @@ public class ModelTests
         Assert.False(config.SingleFile);
         Assert.True(config.IncludeEntities);
         Assert.True(config.IncludeGlobalOptionSets);
-        Assert.True(config.IncludeRelationships);
         Assert.False(config.IncludeReferenceData);
-        Assert.True(config.IncludeComments);
         Assert.Empty(config.ExcludeAttributes);
     }
 }


### PR DESCRIPTION
## Summary
- Same pattern as #100/#101: `ConstantsOutputConfig.IncludeComments`/`IncludeRelationships` were never even assigned from `filterConfig` in `ConstantsCommand.ExecuteAsync`'s `outputConfig` initializer (they just sat at their default `true`), and neither `ConstantsGenerator` nor `CodeTemplateGenerator` ever read them.
- The real behavior is controlled entirely by `CodeTemplateGenerator`'s constructor-time `_includeComments`/`_includeRelationships` fields, resolved via `ResolveIncludeComments`/`ResolveIncludeRelationships` (added in #99).
- `ConstantsConfig.IncludeComments`/`IncludeRelationships` (the ones that actually drive behavior) are untouched.

Fixes #102

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — 416/416 passing
- [x] `grep -rn "IncludeComments\|IncludeRelationships"` confirms every remaining reference is to the live `ConstantsConfig` properties, not the removed `ConstantsOutputConfig` ones