### PR TITLE
fix: report TargetExistingCount in refdata-migrate's N:N relationship table

### DIFF
--- a/src/PowerApps.CLI/Services/MigrationReporter.cs
+++ b/src/PowerApps.CLI/Services/MigrationReporter.cs
@@ -142,11 +142,12 @@ public class MigrationReporter : IMigrationReporter
             worksheet.Cell(row, 2).Value = "Entity 1";
             worksheet.Cell(row, 3).Value = "Entity 2";
             worksheet.Cell(row, 4).Value = "Source Count";
-            worksheet.Cell(row, 5).Value = "Associated";
-            worksheet.Cell(row, 6).Value = "Disassociated";
-            worksheet.Cell(row, 7).Value = "Errors";
+            worksheet.Cell(row, 5).Value = "Target Existing";
+            worksheet.Cell(row, 6).Value = "Associated";
+            worksheet.Cell(row, 7).Value = "Disassociated";
+            worksheet.Cell(row, 8).Value = "Errors";
 
-            var m2mHeaderRange = worksheet.Range(row, 1, row, 7);
+            var m2mHeaderRange = worksheet.Range(row, 1, row, 8);
             m2mHeaderRange.Style.Font.Bold = true;
             m2mHeaderRange.Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             var m2mStartRow = row;
@@ -158,18 +159,19 @@ public class MigrationReporter : IMigrationReporter
                 worksheet.Cell(row, 2).Value = m2mResult.Entity1Name;
                 worksheet.Cell(row, 3).Value = m2mResult.Entity2Name;
                 worksheet.Cell(row, 4).Value = m2mResult.SourceCount;
-                worksheet.Cell(row, 5).Value = m2mResult.AssociatedCount;
-                worksheet.Cell(row, 6).Value = m2mResult.DisassociatedCount;
-                worksheet.Cell(row, 7).Value = m2mResult.Errors.Count;
+                worksheet.Cell(row, 5).Value = m2mResult.TargetExistingCount;
+                worksheet.Cell(row, 6).Value = m2mResult.AssociatedCount;
+                worksheet.Cell(row, 7).Value = m2mResult.DisassociatedCount;
+                worksheet.Cell(row, 8).Value = m2mResult.Errors.Count;
 
                 if (m2mResult.Errors.Count > 0)
                 {
-                    worksheet.Cell(row, 7).Style.Font.FontColor = XLColor.Red;
+                    worksheet.Cell(row, 8).Style.Font.FontColor = XLColor.Red;
                 }
                 row++;
             }
 
-            var m2mTableRange = worksheet.Range(m2mStartRow, 1, row - 1, 7);
+            var m2mTableRange = worksheet.Range(m2mStartRow, 1, row - 1, 8);
             var m2mTable = m2mTableRange.CreateTable();
             m2mTable.Theme = XLTableTheme.TableStyleLight9;
         }

--- a/tests/PowerApps.CLI.Tests/Services/MigrationReporterTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/MigrationReporterTests.cs
@@ -1,0 +1,87 @@
+using ClosedXML.Excel;
+using Moq;
+using PowerApps.CLI.Infrastructure;
+using PowerApps.CLI.Models;
+using PowerApps.CLI.Services;
+using Xunit;
+
+namespace PowerApps.CLI.Tests.Services;
+
+public class MigrationReporterTests : IDisposable
+{
+    private readonly Mock<IFileWriter> _mockFileWriter;
+    private readonly MigrationReporter _reporter;
+    private readonly string _tempDirectory;
+
+    public MigrationReporterTests()
+    {
+        _mockFileWriter = new Mock<IFileWriter>();
+        _reporter = new MigrationReporter(_mockFileWriter.Object);
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"PowerAppsCLI_Tests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDirectory);
+
+        _mockFileWriter
+            .Setup(x => x.WriteBytesAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
+            .Returns((string path, byte[] content) => File.WriteAllBytesAsync(path, content));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, true);
+        }
+    }
+
+    [Fact]
+    public void Constructor_WithNullFileWriter_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new MigrationReporter(null!));
+    }
+
+    [Fact]
+    public async Task GenerateReportAsync_WithManyToManyResult_IncludesTargetExistingCountAsync()
+    {
+        // Arrange
+        var outputPath = Path.Combine(_tempDirectory, "m2m-report.xlsx");
+        var summary = new MigrationSummary
+        {
+            SourceEnvironment = "https://dev.crm.dynamics.com",
+            TargetEnvironment = "https://test.crm.dynamics.com",
+            ManyToManyResults =
+            {
+                new ManyToManyMigrationResult
+                {
+                    RelationshipName = "contact_leads",
+                    Entity1Name = "contact",
+                    Entity2Name = "lead",
+                    SourceCount = 10,
+                    TargetExistingCount = 4,
+                    AssociatedCount = 6,
+                    DisassociatedCount = 1
+                }
+            }
+        };
+
+        // Act
+        await _reporter.GenerateReportAsync(summary, outputPath);
+
+        // Assert
+        using var workbook = new XLWorkbook(outputPath);
+        var summarySheet = workbook.Worksheet("Migration Summary");
+
+        var headerRow = summarySheet.Rows()
+            .First(r => r.Cell(1).GetString() == "Relationship");
+        Assert.Equal("Target Existing", headerRow.Cell(5).GetString());
+        Assert.Equal("Associated", headerRow.Cell(6).GetString());
+        Assert.Equal("Disassociated", headerRow.Cell(7).GetString());
+        Assert.Equal("Errors", headerRow.Cell(8).GetString());
+
+        var dataRow = summarySheet.Row(headerRow.RowNumber() + 1);
+        Assert.Equal("contact_leads", dataRow.Cell(1).GetString());
+        Assert.Equal(10, dataRow.Cell(4).GetValue<int>());
+        Assert.Equal(4, dataRow.Cell(5).GetValue<int>());
+        Assert.Equal(6, dataRow.Cell(6).GetValue<int>());
+        Assert.Equal(1, dataRow.Cell(7).GetValue<int>());
+    }
+}


### PR DESCRIPTION
## Summary
- `ManyToManyMigrationResult.TargetExistingCount` was computed in `RefDataMigrator.cs:389` (how many N:N associations already existed in the target before migration) and already logged verbosely per-relationship, but `MigrationReporter` never included it in the N:N relationship table in the generated XLSX report — the value reached the console log but was silently dropped from the actual report artifact.
- Added a "Target Existing" column between "Source Count" and "Associated" in the N:N relationship table (column indices shifted: Associated 5→6, Disassociated 6→7, Errors 7→8).
- No unit test coverage existed for `MigrationReporter` at all; added `MigrationReporterTests.cs` covering the constructor null-guard and the new column (opens the generated XLSX back up via ClosedXML and asserts header/values).

Fixes #103

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — 418/418 passing (2 new tests for `MigrationReporter`)