### PR TITLE
fix: align single-file mode namespace with multi-file mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,6 +813,8 @@ Generates two files:
 - `Tables.cs` - All entity constants in one file
 - `Choices.cs` - All global option set constants in one file
 
+Namespaces match Multiple Files Mode (`{Namespace}.Tables` / `{Namespace}.Choices`), so switching `--single-file` on or off doesn't require updating any code that references the generated constants.
+
 ## Architecture
 
 ```

--- a/src/PowerApps.CLI/Services/ConstantsGenerator.cs
+++ b/src/PowerApps.CLI/Services/ConstantsGenerator.cs
@@ -66,10 +66,12 @@ public class ConstantsGenerator : IConstantsGenerator
         ConstantsOutputConfig outputConfig,
         IConsoleLogger logger)
     {
-        // Generate entities file
+        // Generate entities file — namespace matches multi-file mode's {Namespace}.Tables so
+        // generated code doesn't need to change if --single-file is toggled later.
         if (outputConfig.IncludeEntities && entities.Count > 0)
         {
             logger.LogInfo($"  Generating Tables.cs with {entities.Count} entit{(entities.Count == 1 ? "y" : "ies")}...");
+            var tablesNamespace = $"{outputConfig.Namespace}.Tables";
             var usedClassNames = new HashSet<string>();
             var classContents = entities.Select(e =>
             {
@@ -77,16 +79,17 @@ public class ConstantsGenerator : IConstantsGenerator
                     _formatter.ToIdentifier(e.DisplayName ?? e.SchemaName ?? e.LogicalName),
                     usedClassNames);
                 usedClassNames.Add(className);
-                return _templateGenerator.GenerateEntityClass(e, outputConfig.Namespace, className);
+                return _templateGenerator.GenerateEntityClass(e, tablesNamespace, className);
             });
-            var content = _templateGenerator.GenerateSingleFile(outputConfig.Namespace, classContents);
+            var content = _templateGenerator.GenerateSingleFile(tablesNamespace, classContents);
             await _fileWriter.WriteTextAsync(Path.Combine(outputConfig.OutputPath, "Tables.cs"), content);
         }
 
-        // Generate global option sets file
+        // Generate global option sets file — namespace matches multi-file mode's {Namespace}.Choices.
         if (outputConfig.IncludeGlobalOptionSets && globalOptionSets != null && globalOptionSets.Count > 0)
         {
             logger.LogInfo($"  Generating Choices.cs with {globalOptionSets.Count} option set(s)...");
+            var choicesNamespace = $"{outputConfig.Namespace}.Choices";
             var usedClassNames = new HashSet<string>();
             var classContents = globalOptionSets.Select(o =>
             {
@@ -94,9 +97,9 @@ public class ConstantsGenerator : IConstantsGenerator
                     _formatter.ToIdentifier(o.DisplayName ?? o.Name ?? "UnknownOptionSet"),
                     usedClassNames);
                 usedClassNames.Add(className);
-                return _templateGenerator.GenerateGlobalOptionSetClass(o, outputConfig.Namespace, className);
+                return _templateGenerator.GenerateGlobalOptionSetClass(o, choicesNamespace, className);
             });
-            var content = _templateGenerator.GenerateSingleFile(outputConfig.Namespace, classContents);
+            var content = _templateGenerator.GenerateSingleFile(choicesNamespace, classContents);
             await _fileWriter.WriteTextAsync(Path.Combine(outputConfig.OutputPath, "Choices.cs"), content);
         }
     }

--- a/tests/PowerApps.CLI.Tests/Services/ConstantsGeneratorTests.cs
+++ b/tests/PowerApps.CLI.Tests/Services/ConstantsGeneratorTests.cs
@@ -335,6 +335,113 @@ public class ConstantsGeneratorTests
     }
 
     [Fact]
+    public async Task GenerateAsync_UsesCorrectNamespaceForSingleFileAsync()
+    {
+        // Arrange — single-file mode's namespace must match multi-file mode's ({Namespace}.Tables) so
+        // switching --single-file on/off doesn't change generated code's fully-qualified type names.
+        var mockTemplateGenerator = new Mock<ICodeTemplateGenerator>();
+        var mockFilter = new Mock<IConstantsFilter>();
+        var mockFileWriter = new Mock<IFileWriter>();
+        var mockLogger = new Mock<IConsoleLogger>();
+
+        mockTemplateGenerator
+            .Setup(x => x.GenerateEntityClass(It.IsAny<EntitySchema>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns("content");
+        mockTemplateGenerator
+            .Setup(x => x.GenerateSingleFile(It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+            .Returns((string _, IEnumerable<string> contents) =>
+            {
+                // Force the lazy Select in GenerateSingleFileModeAsync to run — the real
+                // CodeTemplateGenerator.GenerateSingleFile enumerates via foreach, but this mock
+                // otherwise wouldn't, and GenerateEntityClass would never actually be invoked.
+                contents.ToList();
+                return "combined content";
+            });
+
+        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
+        var entities = new List<EntitySchema>
+        {
+            new EntitySchema { LogicalName = "contact", DisplayName = "Contact" }
+        };
+        var outputConfig = new ConstantsOutputConfig
+        {
+            OutputPath = "./output",
+            Namespace = "MyCompany.Constants",
+            SingleFile = true,
+            IncludeEntities = true,
+            IncludeGlobalOptionSets = false
+        };
+
+        // Act
+        await generator.GenerateAsync(entities, outputConfig, mockLogger.Object);
+
+        // Assert
+        mockTemplateGenerator.Verify(x => x.GenerateEntityClass(
+            It.IsAny<EntitySchema>(),
+            "MyCompany.Constants.Tables",
+            "Contact"), Times.Once);
+        mockTemplateGenerator.Verify(x => x.GenerateSingleFile(
+            "MyCompany.Constants.Tables",
+            It.IsAny<IEnumerable<string>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_SingleFile_UsesCorrectNamespaceForOptionSetsAsync()
+    {
+        // Arrange
+        var mockTemplateGenerator = new Mock<ICodeTemplateGenerator>();
+        var mockFilter = new Mock<IConstantsFilter>();
+        var mockFileWriter = new Mock<IFileWriter>();
+        var mockLogger = new Mock<IConsoleLogger>();
+
+        var globalOptionSets = new List<OptionSetSchema>
+        {
+            new OptionSetSchema { Name = "statuscode", IsGlobal = true }
+        };
+
+        mockFilter
+            .Setup(x => x.ExtractGlobalOptionSets(It.IsAny<List<EntitySchema>>()))
+            .Returns(globalOptionSets);
+        mockTemplateGenerator
+            .Setup(x => x.GenerateGlobalOptionSetClass(It.IsAny<OptionSetSchema>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns("content");
+        mockTemplateGenerator
+            .Setup(x => x.GenerateSingleFile(It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+            .Returns((string _, IEnumerable<string> contents) =>
+            {
+                // Force the lazy Select in GenerateSingleFileModeAsync to run — see comment in
+                // GenerateAsync_UsesCorrectNamespaceForSingleFileAsync.
+                contents.ToList();
+                return "combined content";
+            });
+
+        var generator = new ConstantsGenerator(mockTemplateGenerator.Object, mockFilter.Object, mockFileWriter.Object, new IdentifierFormatter());
+
+        var entities = new List<EntitySchema> { new EntitySchema { LogicalName = "contact" } };
+        var outputConfig = new ConstantsOutputConfig
+        {
+            OutputPath = "./output",
+            Namespace = "MyCompany.Constants",
+            SingleFile = true,
+            IncludeEntities = false,
+            IncludeGlobalOptionSets = true
+        };
+
+        // Act
+        await generator.GenerateAsync(entities, outputConfig, mockLogger.Object);
+
+        // Assert
+        mockTemplateGenerator.Verify(x => x.GenerateGlobalOptionSetClass(
+            It.IsAny<OptionSetSchema>(),
+            "MyCompany.Constants.Choices",
+            "Statuscode"), Times.Once);
+        mockTemplateGenerator.Verify(x => x.GenerateSingleFile(
+            "MyCompany.Constants.Choices",
+            It.IsAny<IEnumerable<string>>()), Times.Once);
+    }
+
+    [Fact]
     public async Task GenerateAsync_SingleFileMode_TwoTablesWithSameDisplayName_DeduplicatesClassNamesAsync()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- `--single-file` mode generated `Tables.cs`/`Choices.cs` under the bare `{Namespace}`, while multi-file mode used `{Namespace}.Tables`/`{Namespace}.Choices` — switching `--single-file` on or off changed every fully-qualified type name in the generated code, so you couldn't toggle between modes without also updating every reference downstream.
- `ConstantsGenerator.GenerateSingleFileModeAsync` now passes `{Namespace}.Tables` / `{Namespace}.Choices` into both the per-class generation calls and `GenerateSingleFile`, matching `GenerateMultipleFilesModeAsync` exactly.
- Added regression tests asserting the single-file namespace (mirroring the existing multi-file namespace tests, which had no single-file counterpart — presumably why this went unnoticed).
- Updated README's Single File Mode section to document the namespace now matches Multiple Files Mode.

**Breaking change note:** this changes single-file mode's generated output for existing users — regenerating after upgrading requires adding `.Tables`/`.Choices` to `using` statements referencing the generated constants. That's the intended fix: the two modes should be interchangeable.

Fixes #106

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — 420/420 passing (2 new namespace regression tests for single-file mode)